### PR TITLE
Resolves #12, updates logger docs, and improves cpu with fd_writer

### DIFF
--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(server echoServer.cc)
+add_executable(server echoServer.cc cmdLogger.cpp)
 target_link_libraries(server PRIVATE quicr-transport)
 
 target_compile_options(server
@@ -12,7 +12,7 @@ set_target_properties(server
         CXX_EXTENSIONS ON)
 
 
-add_executable(client client.cc)
+add_executable(client client.cc cmdLogger.cpp)
 target_link_libraries(client PRIVATE quicr-transport)
 
 target_compile_options(client
@@ -21,7 +21,7 @@ target_compile_options(client
         $<$<CXX_COMPILER_ID:MSVC>: >)
 set_target_properties(client
         PROPERTIES
-        CXX_STANDARD 17
+        CXX_STANDARD 20
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS ON)
 

--- a/cmd/cmdLogger.cpp
+++ b/cmd/cmdLogger.cpp
@@ -1,0 +1,40 @@
+
+#include "cmdLogger.h"
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+
+namespace qtransport {
+
+void cmdLogger::log(LogLevel level, const std::string &string) {
+  char *lvl;
+  switch (level) {
+  case LogLevel::fatal:
+    lvl = "FATAL";
+    break;
+  case LogLevel::error:
+    lvl = "ERROR";
+    break;
+  case LogLevel::warn:
+    lvl = "WARN";
+    break;
+  default:
+    lvl = "INFO";
+    break;
+  }
+
+  auto now = std::chrono::system_clock::now();
+  const auto nowAsTimeT = std::chrono::system_clock::to_time_t(now);
+  const auto nowUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                         now.time_since_epoch()) %
+                     1000000;
+
+	std::lock_guard lock(mutex);
+  std::cout << std::put_time(std::localtime(&nowAsTimeT), "%m-%d-%Y %H:%M:%S")
+            << "." << std::setfill('0') << std::setw(6) << nowUs.count()
+            << std::setfill(' ')
+						<< " " << std::setw(6) << std::right << lvl
+            << std::setw(0) << " | " << string << std::endl;
+
+}
+}; // namespace qtransport

--- a/include/transport/logger.h
+++ b/include/transport/logger.h
@@ -6,17 +6,32 @@ namespace qtransport {
 /**
  * @brief Transport logger level
  */
-enum struct LogLevel : uint8_t {
+enum class LogLevel : uint8_t {
   fatal = 1,
-  error = 2,
-  info = 3,
-  warn = 4,
-  debug = 5,
+  error,
+  warn,
+  info,
+  debug,
 };
 
-struct LogHandler {
-  // log() provides logs to the application.  The default implementation is a
-  // noop; the inputs are ignored.
+/**
+ * @brief Transport log handler
+ *
+ * @details Transport log handler defines callback methods that can be
+ * implemented by the application.
+ */
+class LogHandler {
+public:
+  /**
+   * @brief Transport log callback
+   *
+   * @details Applications can implement this method to receive log messages
+   * from the transport. This is optional.
+   *
+   * @param level			Severity level as defined by
+   * qtransport::LogLevel enum
+   * @param message 	Log messages to log
+   */
   virtual void log(LogLevel /*level*/, const std::string & /*message*/) {}
 };
 } // namespace qtransport

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -13,10 +13,13 @@ ITransport::make_client_transport(const TransportRemote &server,
     return std::make_shared<UDPTransport>(server, delegate, false, logger);
 
   case TransportProtocol::QUIC:
-    assert(0); // TODO  - add handling of protocol not yet implemented
+    logger.log(LogLevel::error, "QUIC not implemented yet");
+		throw std::runtime_error("make_client_transport: QUIC not implemented");
     break;
+
   default:
-    assert(0); // TODO  - add handling of invalid protocol
+    logger.log(LogLevel::error, "Protocol not implemented");
+		  throw std::runtime_error("make_client_transport: Protocol not implemented");
     break;
   }
 
@@ -32,10 +35,13 @@ ITransport::make_server_transport(const TransportRemote &server,
     return std::make_shared<UDPTransport>(server, delegate, true, logger);
 
   case TransportProtocol::QUIC:
-    assert(0); // TODO  - add handling of protocol not yet implemented
+    logger.log(LogLevel::error, "QUIC not implemented yet");
+		  throw std::runtime_error("make_server_transport: QUIC not implemented");
     break;
   default:
-    assert(0); // TODO  - add handling of invalid protocol
+    logger.log(LogLevel::error, "Protocol not implemented");
+
+		  throw std::runtime_error("make_server_transport: Protocol not implemented");
     break;
   }
 

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
+#include <cstring> // memcpy
 #include <iostream>
-#include <string.h> // memcpy
+#include <sstream>
 #include <thread>
 #include <unistd.h>
 
@@ -24,7 +25,7 @@ UDPTransport::~UDPTransport() {
 UDPTransport::UDPTransport(const TransportRemote &server,
                            TransportDelegate &delegate, bool isServerMode,
                            LogHandler &logger)
-    : delegate(delegate) {
+    : delegate(delegate), logger(logger) {
 
   this->isServerMode = isServerMode;
   serverInfo = server;
@@ -43,6 +44,9 @@ MediaStreamId UDPTransport::createMediaStream(
     bool use_reliable_transport) {
 
   if (remote_contexts.count(context_id) == 0) {
+    std::stringstream err;
+    err << "Invalid context id: " << context_id;
+    logger.log(LogLevel::error, err.str());
     return 0; // Error
   }
 
@@ -147,10 +151,11 @@ void UDPTransport::addr_to_remote(sockaddr_storage &addr,
  *  - loop reads data from fd_write_queue and writes it to the socket
  */
 void UDPTransport::fd_writer(const bool &stop) {
-  std::cout << "Starting transport writer thread" << std::endl;
+
+  logger.log(LogLevel::info, "Starting transport writer thread");
 
   while (not stop) {
-    auto cd = fd_write_queue.pop();
+    auto cd = fd_write_queue.block_pop();
 
     if (cd) {
       if (dequeue_data_map.count(cd->mStreamId) == 0 or
@@ -167,17 +172,14 @@ void UDPTransport::fd_writer(const bool &stop) {
                  0 /*flags*/, (struct sockaddr *)&r.addr, sizeof(sockaddr_in));
 
       if (numSent < 0) {
-        int e = errno;
-        std::cerr << "sending on UDP socket got error: " << strerror(e)
-                  << std::endl;
+        std::stringstream err;
+        err << "Error sending on UDP socket: " << strerror(errno);
+        logger.log(LogLevel::error, err.str());
         assert(0); // TODO
 
       } else if (numSent != (int)cd.value().data.size()) {
         assert(0); // TODO
       }
-
-    } else {
-      std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
   }
 }
@@ -196,11 +198,10 @@ void UDPTransport::fd_writer(const bool &stop) {
  * mediaStreamId
  */
 void UDPTransport::fd_reader(const bool &stop) {
-  std::cout << "Starting transport reader thread" << std::endl;
+  logger.log(LogLevel::info, "Starting transport reader thread");
 
-  const int dataSize = 9000; // TODO Add config var to set this value, can be up
-                             // to 64k with gso/ip frags
-
+  const int dataSize = 65535; // TODO Add config var to set this value.  Sizes
+                              // larger than actual MTU require IP frags
   struct sockaddr_storage remoteAddr;
   memset(&remoteAddr, 0, sizeof(remoteAddr));
   socklen_t remoteAddrLen = sizeof(remoteAddr);
@@ -213,15 +214,14 @@ void UDPTransport::fd_reader(const bool &stop) {
                         (struct sockaddr *)&remoteAddr, &remoteAddrLen);
 
     if (rLen < 0) {
-      int e = errno;
-      if (e == EAGAIN) {
+      if (errno == EAGAIN) {
         // timeout on read
         continue;
 
       } else {
-        std::cerr << "reading from UDP socket got error: " << strerror(e)
-                  << std::endl;
-        assert(0); // TODO
+        std::stringstream err;
+        err << "Error reading from UDP socket: " << strerror(errno);
+        logger.log(LogLevel::error, err.str());
       }
     }
 
@@ -312,8 +312,7 @@ TransportError UDPTransport::enqueue(const TransportContextId &context_id,
   connData cd;
   cd.data = bytes;
   cd.contextId = context_id;
-  cd.mStreamId = mStreamId; // Always use stream ID 0 since UDP does not have
-                            // multiple streams
+  cd.mStreamId = mStreamId;
 
   if (not fd_write_queue.push(cd)) {
     return TransportError::QueueFull;
@@ -327,12 +326,18 @@ UDPTransport::dequeue(const TransportContextId &context_id,
                       const MediaStreamId &mstreamId) {
 
   if (remote_contexts.count(context_id) == 0) {
+    std::stringstream err;
+    err << "dequeue: invalid context id: " << context_id;
+    logger.log(LogLevel::warn, err.str());
     // Invalid context id
     return std::nullopt;
   }
 
   if (dequeue_data_map[context_id].count(context_id) == 0) {
-    // Invalid stream Id
+    std::stringstream err;
+    err << "dequeue: invalid stream id: " << mstreamId;
+    logger.log(LogLevel::warn, err.str());
+
     return std::nullopt;
   }
 
@@ -346,6 +351,8 @@ UDPTransport::dequeue(const TransportContextId &context_id,
 }
 
 TransportContextId UDPTransport::connect_client() {
+  std::stringstream s_log;
+
   fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
   if (fd == -1) {
     throw std::runtime_error("socket() failed");
@@ -357,7 +364,9 @@ TransportContextId UDPTransport::connect_client() {
   srvAddr.sin_port = 0;
   int err = bind(fd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
   if (err) {
-    assert(0);
+    s_log << "client_connect: Unable to bind to socket: " << strerror(errno);
+    logger.log(LogLevel::fatal, s_log.str());
+    throw std::runtime_error(s_log.str());
   }
 
   std::string sPort = std::to_string(htons(serverInfo.port));
@@ -368,7 +377,11 @@ TransportContextId UDPTransport::connect_client() {
   err = getaddrinfo(serverInfo.host_or_ip.c_str(), sPort.c_str(), &hints,
                     &address_list);
   if (err) {
-    assert(0);
+    strerror(1);
+    s_log << "client_connect: Unable to resolve remote ip address: "
+          << strerror(errno);
+    logger.log(LogLevel::fatal, s_log.str());
+    throw std::runtime_error(s_log.str());
   }
 
   struct addrinfo *item = nullptr, *found_addr = nullptr;
@@ -381,7 +394,8 @@ TransportContextId UDPTransport::connect_client() {
   }
 
   if (found_addr == nullptr) {
-    assert(0);
+    logger.log(LogLevel::fatal, "client_connect: No IP address found");
+    throw std::runtime_error("client_connect: No IP address found");
   }
 
   struct sockaddr_in *ipv4 = (struct sockaddr_in *)&serverAddr.addr;
@@ -414,9 +428,13 @@ TransportContextId UDPTransport::connect_client() {
 }
 
 TransportContextId UDPTransport::connect_server() {
+  std::stringstream s_log;
+
   fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
   if (fd < 0) {
-    assert(0); // TODO
+    s_log << "connect_server: Unable to create socket: " << strerror(errno);
+    logger.log(LogLevel::fatal, s_log.str());
+    throw std::runtime_error(s_log.str());
   }
 
   // set for re-use
@@ -424,7 +442,9 @@ TransportContextId UDPTransport::connect_server() {
   int err =
       setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&one, sizeof(one));
   if (err != 0) {
-    assert(0); // TODO
+    s_log << "connect_server: setsockopt error: " << strerror(errno);
+    logger.log(LogLevel::fatal, s_log.str());
+    throw std::runtime_error(s_log.str());
   }
 
   struct sockaddr_in srv_addr;
@@ -435,11 +455,14 @@ TransportContextId UDPTransport::connect_server() {
 
   err = bind(fd, (struct sockaddr *)&srv_addr, sizeof(srv_addr));
   if (err < 0) {
-    assert(0); // TODO
+    s_log << "connect_server: unable to bind to socket: " << strerror(errno);
+    logger.log(LogLevel::fatal, s_log.str());
+    throw std::runtime_error(s_log.str());
   }
 
-  std::cout << "UdpSocket: port " << serverInfo.port << ", fd " << fd
-            << std::endl;
+  s_log.str(std::string());
+  s_log << "connect_server: port: " << serverInfo.port << " fd: " << fd;
+  logger.log(LogLevel::info, s_log.str());
 
   bool stop = false;
   std::thread fd_reader_thr(&UDPTransport::fd_reader, this, stop);

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -92,6 +92,7 @@ private:
     MediaStreamId msid;
   };
 
+  LogHandler &logger;
   int fd; // UDP socket
   bool isServerMode;
 


### PR DESCRIPTION
fd_writer() used to use a sleep, which was inefficient and introduced additional delays. The new ```block_pop()``` method adds blocking to the queue if the queue is empty.  This improves CPU and removes the additional delay caused by the sleep.

Instead of using asserts, throws were added. The caller should catch these. Logging has been added.