### PR TITLE
Fix safe queue to start with lock set for empty queue

### DIFF
--- a/src/safe_queue.h
+++ b/src/safe_queue.h
@@ -28,7 +28,11 @@ public:
    * @param limit     Limit number of messages in queue before push blocks. Zero
    *                  is unlimited.
    */
-  safeQueue(uint32_t limit = 1000) { this->limit = limit; }
+  safeQueue(uint32_t limit = 1000)
+  {
+    this->limit = limit;
+    empty_block_mutex.try_lock();
+  }
 
   ~safeQueue() {}
 

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -329,6 +329,7 @@ UDPTransport::fd_reader()
     // Add data to caller queue for processing
     auto& dq = dequeue_data_map[cd.contextId][cd.mStreamId];
 
+    // TODO: Notify caller that packets are being dropped on queue full
     dq.push(cd);
 
     if (dq.size() < 2) {


### PR DESCRIPTION
When safe queue is initialized, the empty lock was not set. This resulted in CPU running at 100% for the ```fd_writer()``` thread.  This would go away as soon as something was pushed to the queue.  Safe queue should have started with empty as locked to prevent this. 