### PR TITLE
Addressed some threading issues that prevented proper shutdown

### DIFF
--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -3,7 +3,7 @@
 
 #include <cassert>
 #include <cstdint>
-#include <list>
+#include <vector>
 #include <map>
 #include <mutex>
 #include <queue>
@@ -91,7 +91,7 @@ private:
   void fd_writer();
 
   bool stop;
-  std::list<std::thread*> running_threads;
+  std::vector<std::thread> running_threads;
 
   struct Addr
   {


### PR DESCRIPTION
I was trying to add code to properly shut down the "really" server and I found threads were getting hung, mutexes were being accessed when they should not, logger reference was accessed when it no longer existed.

I addressed part of the issues here, part in forthcoming changes to "really".

I noted that references are being passed around and stored in objects.  For example:

```cpp
LogHandler& logger;
```

This is in transport_udp.h.  If this transport object is not destroyed before the parent, this causes a crash.  This is _exactly_ like passing around raw pointers.  We should be using shared pointers for such things like this.  That, or use weak pointers and check each before accessing.  Generally, the latter is no needed so long as one doesn't create circular dependencies.