### PR TITLE
Small memory leak fix.

### DIFF
--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -479,6 +479,8 @@ UDPTransport::connect_client()
   ipv4->sin_port = htons(serverInfo.port);
   serverAddr.addr_len = sizeof(sockaddr_in);
 
+  freeaddrinfo(address_list);
+
   addrKey sa_key;
   addr_to_key(serverAddr.addr, sa_key);
 


### PR DESCRIPTION
getaddrinfo needs a corresponding freeaddrinfo.

I think I put this in the right place. 

Not sure if it needs a check first to see if the address list is null.
