### PR TITLE
Ensure picoquic config initialized before use

### DIFF
--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -454,6 +454,7 @@ PicoQuicTransport::PicoQuicTransport(const TransportRemote& server,
 {
     debug = tcfg.debug;
 
+    picoquic_config_init(&config);
     if (_is_server_mode && tcfg.tls_cert_filename == NULL) {
         throw InvalidConfigException("Missing cert filename");
     } else if (tcfg.tls_cert_filename != NULL) {


### PR DESCRIPTION
Not initializing config was causing a bad `free` to occur when later setting config options. 