### PR TITLE
Add back picoquic debug with more logging

### DIFF
--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -544,7 +544,10 @@ TransportContextId
 PicoQuicTransport::start()
 {
     uint64_t current_time = picoquic_current_time();
-    //debug_set_stream(stdout); // Enable picoquic debug
+
+    if (debug) {
+        debug_set_stream(stdout); // Enable picoquic debug
+    }
 
     (void)picoquic_config_set_option(&config, picoquic_option_ALPN, QUICR_ALPN);
     (void)picoquic_config_set_option(&config, picoquic_option_MAX_CONNECTIONS, "100");

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -227,7 +227,9 @@ pq_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* ca
     std::ostringstream log_msg;
 
     if (transport == NULL) {
+        std::cerr << "picoquic transport was called with NULL transport" << std::endl;
         return PICOQUIC_ERROR_UNEXPECTED_ERROR;
+
     } else {
         transport->pq_runner();
 
@@ -328,7 +330,8 @@ pq_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* ca
             }
 
             default:
-                ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
+                //ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
+                transport->logger.log(LogLevel::warn, "pq_loop_cb() does not implement " + std::to_string(cb_mode));
                 break;
         }
     }


### PR DESCRIPTION
Add back picoquic debug if debug is enabled (`LAPS_DEBUG=1`).  This also adds a few more debug/error logs to catch on-off issues. 