### PR TITLE
Code to retrieve the remove address for a transport context

### DIFF
--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <queue>
 #include <vector>
+#include <sys/socket.h>
 
 #include "logger.h"
 
@@ -243,6 +244,17 @@ public:
    */
   virtual void closeStream(const TransportContextId& context_id,
                            StreamId stream_id) = 0;
+
+  /**
+   * @brief Get the peer IP address and port associated with the stream
+   *
+   * @param[in]  context_id	Identifying the connection
+   * @param[out] addr	Peer address
+   *
+   * @returns True if the address was successfully returned, false otherwise
+   */
+  virtual bool getPeerAddrInfo(const TransportContextId& context_id,
+                               sockaddr_storage* addr) = 0;
 
   /**
    * @brief Enqueue application data within the transport

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -54,6 +54,7 @@ class PicoQuicTransport : public ITransport
         uint64_t stream_id;
         TransportContextId context_id;
         picoquic_cnx_t *cnx;
+        sockaddr_storage peer_addr;
         char peer_addr_text[45];
         uint16_t peer_port;
         uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
@@ -96,6 +97,9 @@ class PicoQuicTransport : public ITransport
     void close(const TransportContextId& context_id) override;
     void closeStream(const TransportContextId& context_id,
                      StreamId stream_id) override;
+
+    virtual bool getPeerAddrInfo(const TransportContextId& context_id,
+                                 sockaddr_storage* addr) override;
 
     StreamId createStream(const TransportContextId& context_id,
                           bool use_reliable_transport) override;

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -102,6 +102,22 @@ UDPTransport::closeStream(const TransportContextId& context_id,
   }
 }
 
+bool
+UDPTransport::getPeerAddrInfo(const TransportContextId& context_id,
+                              sockaddr_storage* addr)
+{
+  // Locate the given transport context
+  auto it = remote_contexts.find(context_id);
+
+  // If not found, return false
+  if (it == remote_contexts.end()) return false;
+
+  // Copy the address information
+  std::memcpy(addr, &it->second.addr, sizeof(it->second.addr));
+
+  return true;
+}
+
 void
 UDPTransport::close(const TransportContextId& context_id)
 {

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -69,6 +69,9 @@ public:
   void closeStream(const TransportContextId& context_id,
                    StreamId streamId) override;
 
+  virtual bool getPeerAddrInfo(const TransportContextId& context_id,
+                               sockaddr_storage* addr) override;
+
   StreamId createStream(const TransportContextId& context_id,
                         bool use_reliable_transport) override;
 


### PR DESCRIPTION
This will allow one to query the transport (UDP or QUIC) to get the peer's IP address.