### PR TITLE
Send byte stream

### DIFF
--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -116,7 +116,7 @@ main()
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
     }
 
-    StreamId stream_id = client->createStream(tcid, false);
+    StreamId stream_id = client->createStream(tcid, true);
 
     std::stringstream s_log;
 

--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -109,7 +109,7 @@ main()
     logger.log(LogLevel::info, "after set client transport client use_count: " + std::to_string(client.use_count()));
 
     auto tcid = client->start();
-    uint8_t data_buf[1200]{ 0 };
+    uint8_t data_buf[4200]{ 0 };
 
     while (client->status() != TransportStatus::Ready) {
         logger.log(LogLevel::info, "Waiting for client to be ready");
@@ -126,7 +126,6 @@ main()
         for (int i = 0; i < 10; i++) {
             (*msg_num)++;
             auto data = bytes(data_buf, data_buf + sizeof(data_buf));
-
 
             client->enqueue(tcid, server.proto == TransportProtocol::UDP ? 1 : stream_id, std::move(data));
         }

--- a/cmd/echoServer.cc
+++ b/cmd/echoServer.cc
@@ -53,7 +53,7 @@ public:
       if (data.has_value()) {
         msgcount++;
 
-        uint32_t *msg_num = (uint32_t *)data.value().data();
+        uint32_t *msg_num = (uint32_t *)data->data();
 
         if (prev_msg_num && (*msg_num - prev_msg_num) > 1) {
             s_log.str(std::string());

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -810,8 +810,6 @@ PicoQuicTransport::send_stream_bytes(StreamContext* stream_cnx, uint8_t* bytes_c
         return; // Only for steams
     }
 
-    std::vector<uint8_t> data;
-
     uint32_t data_len = 0;                                  /// Length of data to follow the 4 byte length
     size_t offset = 0;
     int is_still_active = 0;
@@ -1040,9 +1038,9 @@ void PicoQuicTransport::on_recv_stream_bytes(StreamContext* stream_cnx, uint8_t*
     bool object_complete = false;
 
     if (stream_cnx->stream_rx_object == nullptr) {
-        if (length < 4) {
+        if (length < 5) {
             logger.log(LogLevel::warn, (std::ostringstream()
-                                        << "on_recv_stream_bytes is less than 4, cannot process sid: "
+                                        << "on_recv_stream_bytes is less than 5, cannot process sid: "
                                         << std::to_string(stream_cnx->stream_id)).str());
 
             // TODO: Should reset stream in this case

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -66,11 +66,14 @@ class PicoQuicTransport : public ITransport
         std::unique_ptr<timeQueue> rx_data;                  /// Pending objects received from the network
         std::unique_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
 
-        bytes_t stream_tx_object;                           /// Current object that is being sent as a byte stream
-        size_t stream_tx_object_offset{0};                  /// Pointer offset to next byte to send
+        uint8_t* stream_tx_object {nullptr};                 /// Current object that is being sent as a byte stream
+        size_t stream_tx_object_size {0};                    /// Size of the tx object
+        size_t stream_tx_object_offset{0};                   /// Pointer offset to next byte to send
 
-        bytes_t stream_rx_object;                           /// Current object that is being received via byte stream
-        uint32_t stream_rx_object_size;                     /// Receive object data size to append up to before sending to app
+        uint8_t* stream_rx_object {nullptr};                 /// Current object that is being received via byte stream
+        uint32_t stream_rx_object_size;                      /// Receive object data size to append up to before sending to app
+        size_t stream_rx_object_offset{0};                   /// Pointer offset to next byte to append
+
     };
 
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -38,6 +38,12 @@ class PicoQuicTransport : public ITransport
         uint64_t dgram_spurious {0};
         uint64_t dgram_prepare_send {0};
         uint64_t dgram_sent {0};
+        uint64_t stream_prepare_send {0};
+        uint64_t stream_objects_sent {0};
+        uint64_t stream_bytes_sent {0};
+        uint64_t stream_bytes_recv {0};
+        uint64_t stream_objects_recv {0};
+        uint64_t stream_rx_callbacks {0};
         uint64_t send_null_bytes_ctx {0};
         uint64_t dgram_lost {0};
         uint64_t dgram_received {0};
@@ -59,6 +65,9 @@ class PicoQuicTransport : public ITransport
         uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
         std::unique_ptr<timeQueue> rx_data;                  /// Pending objects received from the network
         std::unique_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
+
+        bytes_t stream_current_object;                       /// Current object that is being sent as a byte stream
+        size_t stream_current_object_offset {0};             /// Pointer offset to next byte to send
     };
 
 
@@ -123,7 +132,9 @@ class PicoQuicTransport : public ITransport
     void deleteStreamContext(const TransportContextId& context_id,
                              const StreamId& stream_id);
 
-    void sendTxData(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
+    void sendNextDatagram(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
+    void sendStreamBytes(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
+
     void on_connection_status(StreamContext *stream_cnx,
                               const TransportStatus status);
     void on_new_connection(StreamContext *stream_cnx);
@@ -168,6 +179,7 @@ class PicoQuicTransport : public ITransport
     safeQueue<std::function<void()>> picoquic_runner_queue;     /// Threads queue functions that picoquic will call via the pq_loop_cb call
 
     std::atomic<bool> stop;
+    std::mutex _state_mutex;                                    /// Used for stream/context/state updates
     std::atomic<TransportStatus> transportStatus;
     std::thread picoQuicThread;
     std::thread cbNotifyThread;

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -66,8 +66,11 @@ class PicoQuicTransport : public ITransport
         std::unique_ptr<timeQueue> rx_data;                  /// Pending objects received from the network
         std::unique_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
 
-        bytes_t stream_current_object;                       /// Current object that is being sent as a byte stream
-        size_t stream_current_object_offset {0};             /// Pointer offset to next byte to send
+        bytes_t stream_tx_object;                           /// Current object that is being sent as a byte stream
+        size_t stream_tx_object_offset{0};                  /// Pointer offset to next byte to send
+
+        bytes_t stream_rx_object;                           /// Current object that is being received via byte stream
+        uint32_t stream_rx_object_size;                     /// Receive object data size to append up to before sending to app
     };
 
 
@@ -132,14 +135,16 @@ class PicoQuicTransport : public ITransport
     void deleteStreamContext(const TransportContextId& context_id,
                              const StreamId& stream_id);
 
-    void sendNextDatagram(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
-    void sendStreamBytes(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
+    void send_next_datagram(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
+    void send_stream_bytes(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
 
     void on_connection_status(StreamContext *stream_cnx,
                               const TransportStatus status);
     void on_new_connection(StreamContext *stream_cnx);
-    void on_recv_data(StreamContext *stream_cnx,
-                      uint8_t* bytes, size_t length);
+    void on_recv_datagram(StreamContext *stream_cnx,
+                          uint8_t* bytes, size_t length);
+    void on_recv_stream_bytes(StreamContext *stream_cnx,
+                             uint8_t* bytes, size_t length);
 
     /**
      * @brief Function run the queue functions within the picoquic thread via the pq_loop_cb


### PR DESCRIPTION
Adds micro fragmentation to support stream byte mode.  This change enables enqueue to support large message object sizes when using streams. Libquicr no longer fragments when using reliable/streams. The transport will transmit the message at the byte level based on the picoquic byte callbacks. The byte callbacks are MTU aware.  The remote side will reassemble bytes till fill object is received. Once received, the object will be sent the the app.  The app has control over the size of objects when sending them. 