### PR TITLE
Fix stream context race condition with picoquic

### DIFF
--- a/include/transport/safe_queue.h
+++ b/include/transport/safe_queue.h
@@ -8,6 +8,7 @@
 #include <queue>
 #include <unistd.h>
 #include <condition_variable>
+#include <iostream>
 
 namespace qtransport {
 
@@ -53,14 +54,14 @@ public:
   {
     bool rval = true;
 
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> _(mutex);
 
     if (queue.empty())
       cv.notify_one();
 
     else if (queue.size() >= _limit) { // Make room by removing first element
-      queue.pop();
-      rval = false;
+     queue.pop();
+     rval = false;
     }
 
     queue.push(elem);
@@ -75,8 +76,7 @@ public:
    */
   std::optional<T> pop()
   {
-    std::lock_guard<std::mutex> lock(mutex);
-
+    std::lock_guard<std::mutex> _(mutex);
     return pop_internal();
   }
 
@@ -87,7 +87,7 @@ public:
     */
   std::optional<T> front()
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> _(mutex);
 
     if (queue.empty()) {
       return std::nullopt;
@@ -102,7 +102,7 @@ public:
   */
   void pop_front()
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> _(mutex);
 
     pop_front_internal();
   }
@@ -138,7 +138,7 @@ public:
    */
   size_t size()
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> _(mutex);
     return queue.size();
   }
 
@@ -156,14 +156,14 @@ public:
    */
   void stop_waiting()
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> _(mutex);
     _stop_waiting = true;
     cv.notify_all();
   }
 
   void set_limit(uint32_t limit)
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::lock_guard<std::mutex> _(mutex);
     _limit = limit;
   }
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -72,7 +72,7 @@ class PicoQuicTransport : public ITransport
         size_t stream_tx_object_offset{0};                   /// Pointer offset to next byte to send
 
         uint8_t* stream_rx_object {nullptr};                 /// Current object that is being received via byte stream
-        uint32_t stream_rx_object_size;                      /// Receive object data size to append up to before sending to app
+        uint32_t stream_rx_object_size {0};                      /// Receive object data size to append up to before sending to app
         size_t stream_rx_object_offset{0};                   /// Pointer offset to next byte to append
 
     };


### PR DESCRIPTION
Detecting a new stream is done by receiving a callback for data to be processed on a stream that has a NULL context. The callback previously created the context and **scheduled** updating picoquic stream context pointer. The update would take place during the next loop callback. The problem is that the callback for loop and events are not in sync.  When messages are received before picoquic has updated the stream context, it would result in a new context being created. This resulted in new queues being created, causing previous messages to be lost.  This problem was primarily seen with relay peering, not with client to relay.   

These changes resolve the issues by moving where we update picoquic stream context. 

