### PR TITLE
Revert shared priority queue

### DIFF
--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -417,7 +417,9 @@ PicoQuicTransport::createStreamContext(picoquic_cnx_t* cnx, uint64_t stream_id)
 
     stream_cnx->rx_data = std::make_unique<safe_queue<bytes_t>>(tconfig.time_queue_size_rx);
 
-    stream_cnx->tx_data = _tx_priority_queue;
+    stream_cnx->tx_data = std::make_unique<priority_queue<bytes_t>>(
+      tconfig.time_queue_max_duration, tconfig.time_queue_bucket_interval, _tick_service,
+      tconfig.time_queue_init_queue_size);
 
     sockaddr* addr;
 
@@ -665,10 +667,6 @@ PicoQuicTransport::start()
 
     TransportContextId cid = 0;
     std::ostringstream log_msg;
-
-    _tx_priority_queue = std::make_shared<priority_queue<bytes_t>>(
-            tconfig.time_queue_max_duration, tconfig.time_queue_bucket_interval, _tick_service,
-            tconfig.time_queue_init_queue_size);
 
     if (_is_server_mode) {
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -64,8 +64,8 @@ class PicoQuicTransport : public ITransport
         char peer_addr_text[45];
         uint16_t peer_port;
         uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
-        std::unique_ptr<safe_queue<bytes_t>> rx_data;         /// Pending objects received from the network
-        std::shared_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
+        std::unique_ptr<safe_queue<bytes_t>> rx_data;        /// Pending objects received from the network
+        std::unique_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
 
         uint8_t* stream_tx_object {nullptr};                 /// Current object that is being sent as a byte stream
         size_t stream_tx_object_size {0};                    /// Size of the tx object
@@ -196,7 +196,6 @@ class PicoQuicTransport : public ITransport
     safe_queue<std::function<void()>> cbNotifyQueue;
 
     safe_queue<std::function<void()>> picoquic_runner_queue;         /// Threads queue functions that picoquic will call via the pq_loop_cb call
-    std::shared_ptr<priority_queue<bytes_t>> _tx_priority_queue;    /// Transmit priority queue used by all streams
 
     std::atomic<bool> stop;
     std::mutex _state_mutex;                                        /// Used for stream/context/state updates


### PR DESCRIPTION
Reverting considering shared PQ doesn't work at the picoquic layer for streams. 