### PR TITLE
Stream close fixes

### DIFF
--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -165,7 +165,7 @@ class PicoQuicTransport : public ITransport
     StreamContext * createStreamContext(picoquic_cnx_t* cnx,
                                        uint64_t stream_id);
     void deleteStreamContext(const TransportContextId& context_id,
-                             const StreamId& stream_id);
+                             const StreamId& stream_id, bool fin_stream=false);
 
     void send_next_datagram(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);
     void send_stream_bytes(StreamContext *stream_cnx, uint8_t* bytes_ctx, size_t max_len);


### PR DESCRIPTION
* Stream closing caused picoquic protocol error, resulting In connections failing. This wasn’t a big deal with clients, but is a problem with peering.
* Updated logging to be more clear with debug/info messages.