### PR TITLE
Updates Picoquic and fixes reset/freeze issue

### DIFF
--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -91,20 +91,13 @@ namespace qtransport {
       private:
         void tick_loop()
         {
-            const auto check_delay = _interval / 2;
-            const auto interval_delta = _interval.count();
-            auto last_time = clock_type::now();
+            const int interval_us = _interval.count();
 
+            timeval sleep_time = {.tv_sec = 0, .tv_usec = interval_us};
             while (!_stop) {
-                auto now = clock_type::now();
-                const auto& diff = (now - last_time).count();
-
-                if (diff >= interval_delta) {
-                    ++_ticks;
-                    last_time += _interval;
-                }
-
-                std::this_thread::sleep_for(check_delay);
+                select(1, NULL, NULL, NULL, &sleep_time);
+                sleep_time.tv_usec = interval_us;
+                ++_ticks;
             }
         }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -386,7 +386,7 @@ int pq_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void
                         close_cnx = picoquic_get_next_cnx(close_cnx);
                     }
 
-                    return 0; //PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP; picoquic_close() will stop the loop
+                    return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
                 }
 
                 break;

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -56,6 +56,7 @@ class PicoQuicTransport : public ITransport
 
         uint64_t rx_buffer_drops {0};                       /// count of receive buffer drops of data due to RESET request
         uint64_t tx_buffer_drops{0};                        /// Count of write buffer drops of data due to RESET request
+        uint64_t tx_queue_discards {0};                     /// Number of objects discarded due to TTL expiry or clear
         uint64_t tx_delayed_callback {0};                   /// Count of times transmit callbacks were delayed
         uint64_t prev_tx_delayed_callback {0};              /// Previous transmit delayed callback value, set each interval
         uint64_t stream_objects_sent {0};
@@ -114,6 +115,18 @@ class PicoQuicTransport : public ITransport
                     delete[] object;
                 }
             }
+
+            void reset_buffer() {
+                if(object != nullptr)
+                {
+                    delete[] object;
+
+                    object = nullptr;
+                    object_hdr_size = 0;
+                    object_size = 0;
+                    object_offset = 0;
+                }
+            }
         };
         std::map<uint64_t, StreamRxBuffer> stream_rx_buffer;        /// Map of stream receive buffers, key is stream_id
 
@@ -129,9 +142,7 @@ class PicoQuicTransport : public ITransport
         DataContext& operator=(DataContext&&) = delete;
 
         ~DataContext() {
-            /*
-             * Free legacy pointers if not null
-             */
+            // Free the TX object
             if (stream_tx_object != nullptr) {
                 delete[] stream_tx_object;
                 stream_tx_object = nullptr;
@@ -145,12 +156,7 @@ class PicoQuicTransport : public ITransport
 
             auto it = stream_rx_buffer.find(stream_id);
             if (it != stream_rx_buffer.end()) {
-                delete[] it->second.object;
-
-                it->second.object = nullptr;
-                it->second.object_hdr_size = 0;
-                it->second.object_size = 0;
-                it->second.object_offset = 0;
+                it->second.reset_buffer();
             }
         }
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -117,15 +117,14 @@ class PicoQuicTransport : public ITransport
             }
 
             void reset_buffer() {
-                if(object != nullptr)
-                {
+                if(object != nullptr) {
                     delete[] object;
-
-                    object = nullptr;
-                    object_hdr_size = 0;
-                    object_size = 0;
-                    object_offset = 0;
                 }
+
+                object = nullptr;
+                object_hdr_size = 0;
+                object_size = 0;
+                object_offset = 0;
             }
         };
         std::map<uint64_t, StreamRxBuffer> stream_rx_buffer;        /// Map of stream receive buffers, key is stream_id


### PR DESCRIPTION
Brings in the latest picoquic as of Dec-11-2023, which includes priority updates/fixes.  This also fixes an issue with resets causing freezing (e.g., received bytes too large). 

Also included in this PR is a change to time service to use `select()` for sleep instead of chrono.  On the raspberryPi, this is a 70% reduction in CPU usage. 

* Resolves #103 
* Resolves #104 