### PR TITLE
Refactor UDP transport

### DIFF
--- a/include/transport/priority_queue.h
+++ b/include/transport/priority_queue.h
@@ -43,7 +43,6 @@ namespace qtransport {
 
       public:
         ~priority_queue() {
-            std::lock_guard<std::mutex> _(_mutex);
         }
 
         /**

--- a/include/transport/priority_queue.h
+++ b/include/transport/priority_queue.h
@@ -42,6 +42,10 @@ namespace qtransport {
         };
 
       public:
+        ~priority_queue() {
+            std::lock_guard<std::mutex> _(_mutex);
+        }
+
         /**
          * Construct a priority queue
          * @param tick_service Shared pointer to tick_service service
@@ -154,13 +158,13 @@ namespace qtransport {
         /**
          * @brief Clear queue
          */
-        void clear() {
+         void clear()
+        {
             std::lock_guard<std::mutex> _(_mutex);
 
-            for (auto& tqueue: _queue) {
-                if (tqueue && !tqueue->empty()) {
+            for (auto& tqueue : _queue) {
+                if (tqueue && !tqueue->empty())
                     tqueue->clear();
-                }
             }
         }
 

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -96,7 +96,7 @@ namespace qtransport {
 
             timeval sleep_time = {.tv_sec = 0, .tv_usec = interval_us};
             while (!_stop) {
-                select(1, NULL, NULL, NULL, &sleep_time);
+                select(0, NULL, NULL, NULL, &sleep_time);
                 sleep_time.tv_usec = interval_us;
                 ++_ticks;
             }

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -31,6 +31,7 @@
 #include <thread>
 #include <type_traits>
 #include <vector>
+#include <sys/select.h>
 
 namespace qtransport {
 

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -314,9 +314,7 @@ namespace qtransport {
             }
         }
 
-      private:
-
-
+    private:
         /**
          * @brief Based on current time, adjust and move the bucket index with time
          *        (sliding window)

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -8,7 +8,6 @@
 #include <cstring>
 #include <ctime>
 #include <iostream>
-#include <netdb.h>
 #include <thread>
 #include <unistd.h>
 
@@ -213,7 +212,7 @@ int pq_event_cb(picoquic_cnx_t* pq_cnx,
             transport->logger->info << "Received RESET stream; conn_id: " << data_ctx->conn_id
                                     << " data_ctx_id: " << data_ctx->data_ctx_id
                                     << " stream_id: " << stream_id
-                                    << " RX buf drops: " << data_ctx->metrics.tx_buffer_drops << std::flush;
+                                    << " RX buf drops: " << data_ctx->metrics.rx_buffer_drops << std::flush;
 
             if (!data_ctx->is_default_context) {
                 transport->deleteDataContext(conn_id, data_ctx->data_ctx_id);
@@ -1209,7 +1208,7 @@ void PicoQuicTransport::on_recv_stream_bytes(DataContext* data_ctx, uint64_t str
 
         if (rx_buf.object_hdr_size < 4) {
 
-            uint16_t len_to_copy = length >= 4 ? 4 - rx_buf.object_hdr_size : 4;
+            uint16_t len_to_copy = length > 4 ? 4 - rx_buf.object_hdr_size : length - rx_buf.object_hdr_size;
 
 
             std::memcpy(&rx_buf.object_size + rx_buf.object_hdr_size,
@@ -1219,6 +1218,8 @@ void PicoQuicTransport::on_recv_stream_bytes(DataContext* data_ctx, uint64_t str
 
             if (rx_buf.object_hdr_size < 4) {
                 logger->debug << "Stream header not complete. hdr " << rx_buf.object_hdr_size
+                              << " conn_id: " << data_ctx->conn_id
+                              << " data_ctx_id: " << data_ctx->data_ctx_id
                               << " len_to_copy: " << len_to_copy
                               << " length: " << length
                               << std::flush;
@@ -1236,8 +1237,9 @@ void PicoQuicTransport::on_recv_stream_bytes(DataContext* data_ctx, uint64_t str
 
         if (rx_buf.object_size > 40000000L) { // Safety check
             logger->warning << "on_recv_stream_bytes stream_id: " << stream_id
-                            << " data length is too large: "
-                            << std::to_string(rx_buf.object_size)
+                            << " conn_id: " << data_ctx->conn_id
+                            << " data_ctx_id: " << data_ctx->data_ctx_id
+                            << " data length is too large: " << rx_buf.object_size
                             << std::flush;
 
             rx_buf.reset_buffer();
@@ -1318,7 +1320,15 @@ void PicoQuicTransport::on_recv_stream_bytes(DataContext* data_ctx, uint64_t str
     }
 
     if (length > 0) {
-        logger->debug << "on_stream_bytes has remaining bytes: " << length << std::flush;
+        logger->debug << "on_recv_stream_bytes has remaining bytes: " << length
+                      << " conn_id: " << data_ctx->conn_id
+                      << " data_ctx_id: " << data_ctx->data_ctx_id
+                      << " stream_id: " << data_ctx->current_stream_id
+                      << " rx_hdr_sz: " << rx_buf.object_hdr_size
+                      << " rx_obj_offset: " << rx_buf.object_offset
+                      << " rx_obj_sz: " << rx_buf.object_size
+                      << std::flush;
+
         on_recv_stream_bytes(data_ctx, stream_id, bytes_p, length);
     }
 }

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1034,7 +1034,7 @@ PicoQuicTransport::send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, 
 
         if (max_len < 5) {
             // Not enough bytes to send
-            logger->debug << "Not enough bytes to send stream size header, waiting for next callback. sid: "
+            logger->debug << "Not enough bytes to send stream size header, waiting for next callback. data_ctx_id: "
                          << data_ctx->current_stream_id << std::flush;
             return;
         }
@@ -1305,7 +1305,7 @@ void PicoQuicTransport::on_recv_stream_bytes(DataContext* data_ctx, uint64_t str
 
         bool too_many_in_queue = false;
         if (cbNotifyQueue.size() > 200) {
-            logger->warning << "on_recv_stream_bytes sid: " << data_ctx->current_stream_id << "cbNotifyQueue size" << cbNotifyQueue.size()
+            logger->warning << "on_recv_stream_bytes data_ctx_id: " << data_ctx->current_stream_id << "cbNotifyQueue size" << cbNotifyQueue.size()
                             << std::flush;
         }
 

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -204,7 +204,7 @@ bool UDPTransport::send_connect(const TransportConnId conn_id, const Addr& addr)
 
     chdr.idle_timeout = 20;
 
-    std::lock_guard<std::mutex> _(_socket_write_mutex);
+    std::lock_guard<std::mutex> _(_send_recv_sync_mutex);
 
     int numSent = sendto(fd,
                          (uint8_t *)&chdr,
@@ -234,7 +234,7 @@ bool UDPTransport::send_connect(const TransportConnId conn_id, const Addr& addr)
 bool UDPTransport::send_disconnect(const TransportConnId conn_id, const Addr& addr) {
     UdpProtocol::DisconnectMsg dhdr {};
 
-    std::lock_guard<std::mutex> _(_socket_write_mutex);
+    std::lock_guard<std::mutex> _(_send_recv_sync_mutex);
 
     int numSent = sendto(fd,
                          (uint8_t *)&dhdr,
@@ -267,7 +267,7 @@ bool UDPTransport::send_keepalive(const TransportConnId conn_id, const Addr &add
     logger->debug << "conn_id: " << conn_id
                   << " send KEEPALIVE" << std::flush;
 
-    std::lock_guard<std::mutex> _(_socket_write_mutex);
+    std::lock_guard<std::mutex> _(_send_recv_sync_mutex);
 
     int numSent = sendto(fd,
                          (uint8_t *)&khdr,
@@ -295,7 +295,7 @@ bool UDPTransport::send_keepalive(const TransportConnId conn_id, const Addr &add
 }
 
 bool UDPTransport::send_report(ConnectionContext& conn) {
-    std::lock_guard<std::mutex> _(_socket_write_mutex);
+    std::lock_guard<std::mutex> _(_send_recv_sync_mutex);
 
     int numSent = sendto(fd,
                          (uint8_t *)&conn.report,
@@ -359,7 +359,7 @@ bool UDPTransport::send_data(ConnectionContext& conn, const ConnData& cd, bool d
 
     dhdr.report_id = conn.report_id;
 
-    std::lock_guard<std::mutex> _(_socket_write_mutex);
+    std::lock_guard<std::mutex> _(_send_recv_sync_mutex);
 
     const auto data_len = sizeof(dhdr) + cd.data.size();
     if (data_len > sizeof(data)) {

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -186,7 +186,7 @@ TransportRemote UDPTransport::create_addr_remote(const sockaddr_storage &addr) {
             inet_ntop(AF_INET, &s->sin_addr, ip, sizeof(ip));
             break;
         }
-        default: {
+        case AF_INET6: {
             // IPv6
             sockaddr_in6 *s = (sockaddr_in6 *) &addr;
 
@@ -194,6 +194,9 @@ TransportRemote UDPTransport::create_addr_remote(const sockaddr_storage &addr) {
             inet_ntop(AF_INET6, &s->sin6_addr, ip, sizeof(ip));
             break;
         }
+        default:
+            logger->error << "Unknown AFI: " << static_cast<int>(addr.ss_family) << std::flush;
+            break;
     }
 
     return std::move(remote);

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -5,191 +5,188 @@
 #include <thread>
 #include <unistd.h>
 
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+
 #if defined(__linux__)
 #include <net/ethernet.h>
 #include <netpacket/packet.h>
 #elif defined(__APPLE__)
+
 #include <net/if_dl.h>
+
 #endif
 
 #include "transport_udp.h"
 
 using namespace qtransport;
 
-UDPTransport::~UDPTransport()
-{
-  // TODO: Close all streams and connections
+UDPTransport::~UDPTransport() {
+    // TODO: Close all streams and connections
 
-  // Stop threads
-  stop = true;
+    // Stop threads
+    stop = true;
 
-  // Clear threads from the queue
-  fd_write_queue.reset();
+    // Close socket fd
+    if (fd >= 0)
+        ::close(fd);
 
-  // Close socket fd
-  if (fd >= 0)
-    ::close(fd);
+    logger->Log("Closing transport threads");
+    for (auto &thread: running_threads) {
+        if (thread.joinable())
+            thread.join();
+    }
 
-  logger->Log("Closing transport threads");
-  for (auto &thread : running_threads) {
-    if (thread.joinable())
-        thread.join();
-  }
-
-  _tick_service.reset();
+    _tick_service.reset();
 }
 
-UDPTransport::UDPTransport(const TransportRemote& server,
-                           TransportDelegate& delegate,
+UDPTransport::UDPTransport(const TransportRemote &server,
+                           TransportDelegate &delegate,
                            bool isServerMode,
-                           const cantina::LoggerPointer& logger)
-  : stop(false)
-  , logger(std::make_shared<cantina::Logger>("UDP", logger))
-  , fd(-1)
-  , isServerMode(isServerMode)
-  , serverInfo(server)
-  , delegate(delegate)
-{
-  _tick_service = std::make_shared<threaded_tick_service>();
-  fd_write_queue = std::make_unique<priority_queue<ConnData>>(
-          1000, 1, _tick_service, 1000);
+                           const cantina::LoggerPointer &logger)
+        : stop(false), logger(std::make_shared<cantina::Logger>("UDP", logger)), fd(-1), isServerMode(isServerMode),
+          serverInfo(server), delegate(delegate) {
+    _tick_service = std::make_shared<threaded_tick_service>();
 }
 
-TransportStatus
-UDPTransport::status() const
-{
-  return (fd > 0) ? TransportStatus::Ready : TransportStatus::Disconnected;
+TransportStatus UDPTransport::status() const {
+    return (fd > 0) ? TransportStatus::Ready : TransportStatus::Disconnected;
 }
 
 /*
  * UDP doesn't support multiple streams for clients.  This will return the same
  * stream ID used for the context
  */
-DataContextId
-UDPTransport::createDataContext(
-  const qtransport::TransportConnId conn_id,
-  [[maybe_unused]] bool use_reliable_transport,
-  [[maybe_unused]] uint8_t priority,
-  [[maybe_unused]] bool bidir)
-{
+DataContextId UDPTransport::createDataContext(const qtransport::TransportConnId conn_id,
+                                              [[maybe_unused]] bool use_reliable_transport,
+                                              uint8_t priority,
+                                              [[maybe_unused]] bool bidir) {
 
-  if (connections.count(conn_id) == 0) {
-    logger->error << "Invalid connection id: " << conn_id << std::flush;
-    return 0; // Error
-  }
+    const auto conn_it = conn_contexts.find(conn_id);
 
-  auto conn = connections[conn_id];
-  return remote_addrs[conn.addr.key].sid;
+    if (conn_it == conn_contexts.end()) {
+        logger->error << "Failed to create data context, invalid connection id: " << conn_id << std::flush;
+        return 0; // Error
+    }
+
+    auto& conn = *conn_it->second;
+
+    // Currently only a single/datagram stream/flow is implemented.
+    auto data_ctx_id = 0;
+
+    const auto& [data_ctx_it, is_new] = conn.data_contexts.try_emplace(data_ctx_id);
+
+    if (is_new) {
+        data_ctx_it->second.data_ctx_id = data_ctx_id;
+        data_ctx_it->second.priority = priority;
+        data_ctx_it->second.rx_data.set_limit(1000);
+        data_ctx_it->second.tx_data = std::make_unique<priority_queue<ConnData>>(1000,
+                                                                                 1,
+                                                                                 _tick_service,
+                                                                                 1000);
+    }
+
+    return data_ctx_id;
 }
 
-TransportConnId
-UDPTransport::start()
-{
+TransportConnId UDPTransport::start() {
+    if (isServerMode) {
+        return connect_server();
+    }
 
-  if (isServerMode) {
-    return connect_server();
-  } else {
     return connect_client();
-  }
-
-  return 0;
 }
 
-void
-UDPTransport::deleteDataContext(const TransportConnId& context_id, DataContextId streamId)
-{
+void UDPTransport::deleteDataContext(const TransportConnId& conn_id, DataContextId data_ctx_id) {
 
-  if (dequeue_data_map[context_id].count(streamId) > 0) {
-    dequeue_data_map[context_id].erase(streamId);
-  }
-}
-
-bool
-UDPTransport::getPeerAddrInfo(const TransportConnId& conn_id,
-                              sockaddr_storage* addr)
-{
-  // Locate the given transport context
-  auto it = connections.find(conn_id);
-
-  // If not found, return false
-  if (it == connections.end()) return false;
-
-  // Copy the address information
-  std::memcpy(addr, &it->second.addr, sizeof(it->second.addr));
-
-  return true;
-}
-
-void
-UDPTransport::close(const TransportConnId& conn_id)
-{
-
-  if (isServerMode) {
-    addrKey ak;
-
-    addr_to_key(connections[conn_id].addr.addr, ak);
-
-    remote_addrs.erase(ak);
-    connections.erase(conn_id);
-    dequeue_data_map.erase(conn_id);
-  }
-}
-
-void
-UDPTransport::addr_to_key(sockaddr_storage& addr, addrKey& key)
-{
-
-  key.port = 0;
-  key.ip_lo = 0;
-  key.ip_hi = 0;
-
-  switch (addr.ss_family) {
-    case AF_INET: {
-      sockaddr_in* s = (sockaddr_in*)&addr;
-
-      key.port = s->sin_port;
-      key.ip_lo = s->sin_addr.s_addr;
-      break;
+    // Do not delete the default datagram context id ZERO
+    if (data_ctx_id > 0) {
+        auto conn_it = conn_contexts.find(conn_id);
+        if (conn_it != conn_contexts.end()) {
+            logger->info << "Delete data context id: " << data_ctx_id << " in conn_id: " << conn_id << std::flush;
+            conn_it->second->data_contexts.erase(data_ctx_id);
+        }
     }
-    default: {
-      // IPv6
-      sockaddr_in6* s = (sockaddr_in6*)&addr;
-
-      key.port = s->sin6_port;
-
-      key.ip_hi = (uint64_t)&s->sin6_addr;
-      key.ip_lo = (uint64_t)&s->sin6_addr + 8;
-      break;
-    }
-  }
 }
 
-void
-UDPTransport::addr_to_remote(sockaddr_storage& addr, TransportRemote& remote)
-{
-  char ip[INET6_ADDRSTRLEN];
+bool UDPTransport::getPeerAddrInfo(const TransportConnId &conn_id,
+                                   sockaddr_storage *addr) {
+    // Locate the given transport context
+    auto it = conn_contexts.find(conn_id);
 
-  remote.proto = TransportProtocol::UDP;
+    // If not found, return false
+    if (it == conn_contexts.end()) return false;
 
-  switch (addr.ss_family) {
-    case AF_INET: {
-      sockaddr_in* s = (sockaddr_in*)&addr;
+    // Copy the address information
+    std::memcpy(addr, &it->second->addr, sizeof(it->second->addr));
 
-      remote.port = s->sin_port;
-      inet_ntop(AF_INET, &s->sin_addr, ip, sizeof(ip));
-      break;
+    return true;
+}
+
+void UDPTransport::close(const TransportConnId &conn_id) {
+
+    if (isServerMode) {
+        auto conn_it = conn_contexts.find(conn_id);
+        if (conn_it != conn_contexts.end()) {
+            addr_conn_contexts.erase(conn_it->second->addr.id);
+            conn_contexts.erase(conn_it);
+        }
     }
-    default: {
-      // IPv6
-      sockaddr_in6* s = (sockaddr_in6*)&addr;
+}
 
-      remote.port = s->sin6_port;
-      inet_ntop(AF_INET6, &s->sin6_addr, ip, sizeof(ip));
-      break;
+AddrId UDPTransport::create_addr_id(const sockaddr_storage &addr) {
+    AddrId id;
+
+    switch (addr.ss_family) {
+        case AF_INET: {
+            sockaddr_in *s = (sockaddr_in *) &addr;
+
+            id.port = s->sin_port;
+            id.ip_lo = s->sin_addr.s_addr;
+            break;
+        }
+        default: {
+            // IPv6
+            sockaddr_in6 *s = (sockaddr_in6 *) &addr;
+
+            id.port = s->sin6_port;
+
+            id.ip_hi = (uint64_t) &s->sin6_addr;
+            id.ip_lo = (uint64_t) &s->sin6_addr + 8;
+            break;
+        }
     }
-  }
+
+    return std::move(id);
+}
+
+TransportRemote UDPTransport::create_addr_remote(const sockaddr_storage &addr) {
+    TransportRemote remote;
+
+    char ip[INET6_ADDRSTRLEN];
+
+    remote.proto = TransportProtocol::UDP;
+
+    switch (addr.ss_family) {
+        case AF_INET: {
+            sockaddr_in *s = (sockaddr_in *) &addr;
+
+            remote.port = s->sin_port;
+            inet_ntop(AF_INET, &s->sin_addr, ip, sizeof(ip));
+            break;
+        }
+        default: {
+            // IPv6
+            sockaddr_in6 *s = (sockaddr_in6 *) &addr;
+
+            remote.port = s->sin6_port;
+            inet_ntop(AF_INET6, &s->sin6_addr, ip, sizeof(ip));
+            break;
+        }
+    }
+
+    return std::move(remote);
 }
 
 /*
@@ -198,62 +195,93 @@ UDPTransport::addr_to_remote(sockaddr_storage& addr, TransportRemote& remote)
  * Writer will perform the following:
  *  - loop reads data from fd_write_queue and writes it to the socket
  */
-void
-UDPTransport::fd_writer() {
+void UDPTransport::fd_writer() {
     timeval to;
     to.tv_usec = 1000;
     to.tv_sec = 0;
 
     logger->Log("Starting transport writer thread");
 
-    const double bytes_per_us = 187'500 /* 1.5Mbps */ / 1'000'000.0 /* 1 second double */;
-
-    logger->info << "Shaping rate to " << bytes_per_us << " Bp_us" << std::flush;
+    bool sent_data = false;
+    int all_empty_count = 0;
 
     while (not stop) {
-        // TODO: Add blocking pop front
+        sent_data = false;
 
-        auto cd = fd_write_queue->pop_front();
+        // Check each connection context for data to send
+        for (const auto& [conn_id, conn]: conn_contexts) {
+            // NOTE: Currently only implement single data context
+            const auto& data_ctx = conn->data_contexts[0];
 
-        if (!cd) {
-            to.tv_usec = 1000;
-            select(0, NULL, NULL, NULL, &to);
+            const auto current_tick = _tick_service->get_ticks(std::chrono::milliseconds (1));
+
+            // Shape flow by only processing data if wait for tick value is less than or equal to current tick
+            if (conn->wait_for_tick > current_tick) {
+                logger->info << "SHAPING conn_id: " << conn_id
+                             << " running_age: " << conn->running_wait_us
+                             << " wait_for_tick: " << conn->wait_for_tick
+                             << " current_tick: " << current_tick
+                             << std::flush;
+                continue;
+            }
+
+            if (data_ctx.tx_data->empty()) // No data, go to next connection
+                continue;
+
+            auto cd = data_ctx.tx_data->pop_front();
+
+            if (!cd) continue; // Data maybe null if queue is polled too fast
+
+            const auto data_len = cd.value().data.size();
+
+            int numSent = sendto(fd,
+                                 cd.value().data.data(),
+                                 data_len,
+                                 0 /*flags*/,
+                                 (struct sockaddr *) &conn->addr.addr,
+                                 sizeof(sockaddr_in));
+
+
+            if (numSent < 0) {
+                logger->error << "conn_id: " << conn_id
+                              << "Error sending on UDP socket: " << strerror(errno)
+                              << std::flush;
+
+                continue;
+
+            } else if (numSent != data_len) {
+                logger->info << "conn_id: " << conn_id
+                             << "Failed to send all data data_size: " << data_len << " sent: " << numSent
+                             << std::flush;
+            }
+
+            sent_data = true;
+
+            // Calculate the wait for tick value
+            conn->running_wait_us += static_cast<int>(data_len / conn->bytes_per_us);
+            if (conn->running_wait_us > 1000) {
+                conn->wait_for_tick = current_tick + conn->running_wait_us / 1000;
+                conn->running_wait_us %= 1000; // Set running age to remainder value less than a tick
+            }
+
+            logger->info << "sent conn_id: " << conn_id
+                         << " pri: " << static_cast<int>(cd->priority)
+                         << " data_len: " << data_len
+                         << " running_age: " << conn->running_wait_us
+                         << " wait_for_tick: " << conn->wait_for_tick
+                         << " current_tick: " << current_tick
+                         << std::flush;
         }
 
-        if ((dequeue_data_map.count(cd->connId) == 0 || dequeue_data_map[cd->connId].count(cd->streamId) == 0)
-            || connections.count(cd->connId) == 0) {
-            // Drop/ignore connection data since the connection or stream no
-            // longer exists
-            continue;
+        if (!sent_data) {
+            all_empty_count++;
+
+            if (all_empty_count > 5) {
+                all_empty_count = 1;
+                to.tv_usec = 1000;
+                select(0, NULL, NULL, NULL, &to);
+            }
         }
-
-        auto &conn = connections.at(cd->connId);
-        const auto data_len = cd.value().data.size();
-
-        int numSent = sendto(fd,
-                             cd.value().data.data(),
-                             data_len,
-                             0 /*flags*/,
-                             (struct sockaddr *) &conn.addr.addr,
-                             sizeof(sockaddr_in));
-
-
-        if (numSent < 0) {
-            logger->error << "Error sending on UDP socket: " << strerror(errno)
-                          << std::flush;
-
-            break;
-
-        } else if (numSent != data_len) {
-            logger->info << "Failed to send all data data_size: " << data_len << " sent: " << numSent << std::flush;
-        }
-
-        // Wait for the amount of time that it should take to transmit current data
-
-        // TODO: check if tv_usec is zero, if so accumulate it
-        to.tv_usec = static_cast<int>(data_len / bytes_per_us);
-        select(0, NULL, NULL, NULL, &to);
-        logger->info << "sent pri: " << static_cast<int>(cd->priority) << " data_len: " << data_len << " us: " << to.tv_usec << std::flush;
     }
 
     logger->Log("Done transport writer thread");
@@ -272,354 +300,338 @@ UDPTransport::fd_writer() {
  * not called again if there is still pending data to be dequeued for the same
  * StreamId
  */
-void
-UDPTransport::fd_reader()
-{
-  logger->Log("Starting transport reader thread");
+void UDPTransport::fd_reader() {
+    logger->Log("Starting transport reader thread");
 
-  const int dataSize = 65535; // TODO Add config var to set this value.  Sizes
-                              // larger than actual MTU require IP frags
-  struct sockaddr_storage remoteAddr;
-  memset(&remoteAddr, 0, sizeof(remoteAddr));
-  socklen_t remoteAddrLen = sizeof(remoteAddr);
+    const int dataSize = 65535; // TODO Add config var to set this value.  Sizes
+    // larger than actual MTU require IP frags
+    uint8_t data[dataSize];
 
-  uint8_t data[dataSize];
+    while (not stop) {
+        Addr remote_addr;
 
-  while (not stop) {
-    int rLen = recvfrom(fd,
-                        data,
-                        dataSize,
-                        0 /*flags*/,
-                        (struct sockaddr*)&remoteAddr,
-                        &remoteAddrLen);
+        int rLen = recvfrom(fd,
+                            data,
+                            dataSize,
+                            0 /*flags*/,
+                            (struct sockaddr *) &remote_addr.addr,
+                            &remote_addr.addr_len);
 
-    if (rLen < 0 || stop) {
-      if ((errno == EAGAIN) || (stop)) {
-        // timeout on read or stop issued
-        continue;
+        if (rLen < 0 || stop) {
+            if ((errno == EAGAIN) || (stop)) {
+                // timeout on read or stop issued
+                continue;
 
-      } else {
-        logger->error << "Error reading from UDP socket: " << strerror(errno)
-                      << std::flush;
-        break;
-      }
+            } else {
+                logger->error << "Error reading from UDP socket: " << strerror(errno)
+                              << std::flush;
+                break;
+            }
+        }
+
+        if (rLen == 0) {
+            continue;
+        }
+
+        std::vector<uint8_t> buffer(data, data + rLen);
+
+        ConnData cd;
+        cd.data = buffer;
+        cd.data_ctx_id = 0; // Currently only implement one data context
+
+        remote_addr.id = create_addr_id(remote_addr.addr);
+
+        const auto a_conn_it = addr_conn_contexts.find(remote_addr.id);
+
+        if (a_conn_it == addr_conn_contexts.end()) { // New connection
+            if (isServerMode) {
+                ++last_conn_id;
+
+                const auto [conn_it, _] = conn_contexts.emplace(last_conn_id,
+                                                                 std::make_shared<ConnectionContext>());
+
+                auto &conn = *conn_it->second;
+
+                createDataContext(last_conn_id, false, 10, false);
+
+                conn.addr = remote_addr;
+                conn.id = last_conn_id;
+                conn.set_bytes_per_us(50000); // Set to 50Mbps connection rate
+
+                addr_conn_contexts.emplace(remote_addr.id, conn_it->second); // Add to the addr lookup map
+
+                // New remote address/connection
+                const TransportRemote remote = create_addr_remote(remote_addr.addr);
+
+                cd.conn_id = last_conn_id;
+
+                // Notify caller that there is a new connection
+                delegate.on_new_connection(last_conn_id, std::move(remote));
+
+                conn_it->second->data_contexts[cd.data_ctx_id].rx_data.push(cd);
+                if (conn_it->second->data_contexts[cd.data_ctx_id].rx_data.size() < 4) {
+                    delegate.on_recv_notify(cd.conn_id, cd.data_ctx_id);
+                }
+
+            } else {
+                // Client mode doesn't support creating connections based on received
+                // packets
+                continue;
+            }
+        } else {
+            cd.conn_id = a_conn_it->second->id;
+            a_conn_it->second->data_contexts[0].rx_data.push(cd);
+            if (a_conn_it->second->data_contexts[0].rx_data.size() < 4) {
+                delegate.on_recv_notify(cd.conn_id, cd.data_ctx_id);
+            }
+        }
     }
 
-    if (rLen == 0) {
-      continue;
-    }
-
-    std::vector<uint8_t> buffer (data, data + rLen);
-
-    ConnData cd;
-    cd.data = buffer;
-    cd.streamId = 0;
-
-    addrKey ra_key;
-    addr_to_key(remoteAddr, ra_key);
-
-    if (remote_addrs.count(ra_key) == 0) {
-      if (isServerMode) {
-        // New remote address/connection
-        TransportRemote remote;
-        addr_to_remote(remoteAddr, remote);
-
-        ConnectionContext conn;
-        conn.addr.key = ra_key;
-        conn.addr.addr_len = remoteAddrLen;
-        memcpy(&(conn.addr.addr), &remoteAddr, remoteAddrLen);
-
-        ++last_conn_id;
-        ++last_stream_id;
-
-        connections[last_conn_id] = std::move(conn);
-        remote_addrs[ra_key] = {
-                last_conn_id,
-                last_stream_id,
-        };
-
-        cd.connId = last_conn_id;
-        cd.streamId = last_stream_id;
-
-        // Create dequeue
-        dequeue_data_map[last_conn_id][last_stream_id].set_limit(1000);
-        cd.connId = last_conn_id;
-
-        // Notify caller that there is a new connection
-        delegate.on_new_connection(last_conn_id, std::move(remote));
-
-      } else {
-        // Client mode doesn't support creating connections based on received
-        // packets
-        continue;
-      }
-    } else {
-      auto sctx = remote_addrs[ra_key];
-      cd.connId = sctx.tcid;
-      cd.streamId = sctx.sid;
-    }
-
-    // Add data to caller queue for processing
-    auto& dq = dequeue_data_map[cd.connId][cd.streamId];
-
-    dq.push(cd);
-
-    if (dq.size() < 4) {
-      // Notify the caller that there is data to process
-      delegate.on_recv_notify(cd.connId, cd.streamId);
-    }
-  }
-
-  logger->Log("Done transport reader thread");
+    logger->Log("Done transport reader thread");
 }
 
-TransportError
-UDPTransport::enqueue(const TransportConnId& context_id,
-                      const DataContextId& streamId,
-                      std::vector<uint8_t>&& bytes,
+TransportError UDPTransport::enqueue(const TransportConnId &conn_id,
+                      const DataContextId &data_ctx_id,
+                      std::vector<uint8_t> &&bytes,
                       const uint8_t priority,
                       const uint32_t ttl_ms,
-                      [[maybe_unused]] const EnqueueFlags flags)
-{
-  if (bytes.empty()) {
-    return TransportError::None;
-  }
-
-  if (connections.count(context_id) == 0) {
-    // Invalid context id
-    return TransportError::InvalidConnContextId;
-  }
-
-  if (dequeue_data_map[context_id].count(streamId) == 0) {
-    // Invalid stream Id
-    return TransportError::InvalidDataContextId;
-  }
-
-  ConnData cd;
-  cd.data = bytes;
-  cd.connId = context_id;
-  cd.streamId = streamId;
-  cd.priority = priority;
-
-  fd_write_queue->push(cd, ttl_ms, priority);
-
-  return TransportError::None;
-}
-
-std::optional<std::vector<uint8_t>>
-UDPTransport::dequeue(const TransportConnId& context_id,
-                      const DataContextId& streamId)
-{
-
-  if (connections.count(context_id) == 0) {
-    logger->warning << "dequeue: invalid context id: " << context_id
-                    << std::flush;
-    // Invalid context id
-    return std::nullopt;
-  }
-
-  if (dequeue_data_map[context_id].count(streamId) == 0) {
-    logger->error << "dequeue: invalid stream id: " << streamId << std::flush;
-
-    return std::nullopt;
-  }
-
-  auto& dq = dequeue_data_map[context_id][streamId];
-
-  if (auto cd = dq.pop()) {
-      return cd.value().data;
-  }
-
-  return std::nullopt;
-}
-
-TransportConnId
-UDPTransport::connect_client()
-{
-  std::stringstream s_log;
-
-  fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-  if (fd == -1) {
-    throw std::runtime_error("socket() failed");
-  }
-
-  // TODO: Add config for these values
-  size_t snd_rcv_max = 64000;
-  timeval rcv_timeout { .tv_sec = 0, .tv_usec = 1000 };
-
-  int err =
-    setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd_rcv_max, sizeof(snd_rcv_max));
-  if (err != 0) {
-    s_log << "client_connect: Unable to set send buffer size: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
-
-  snd_rcv_max = 1000000;
-  err =
-    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &snd_rcv_max, sizeof(snd_rcv_max));
-  if (err != 0) {
-    s_log << "client_connect: Unable to set receive buffer size: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
-
-  err =
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
-  if (err != 0) {
-    s_log << "client_connect: Unable to set receive timeout: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
-
-
-  struct sockaddr_in srvAddr;
-  srvAddr.sin_family = AF_INET;
-  srvAddr.sin_addr.s_addr = htonl(INADDR_ANY);
-  srvAddr.sin_port = 0;
-  err = bind(fd, (struct sockaddr*)&srvAddr, sizeof(srvAddr));
-  if (err) {
-    s_log << "client_connect: Unable to bind to socket: " << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
-
-  std::string sPort = std::to_string(htons(serverInfo.port));
-  struct addrinfo hints = {}, *address_list = NULL;
-  hints.ai_family = AF_INET;
-  hints.ai_socktype = SOCK_DGRAM;
-  hints.ai_protocol = IPPROTO_UDP;
-  err = getaddrinfo(
-    serverInfo.host_or_ip.c_str(), sPort.c_str(), &hints, &address_list);
-  if (err) {
-    strerror(1);
-    s_log << "client_connect: Unable to resolve remote ip address: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
-
-  struct addrinfo *item = nullptr, *found_addr = nullptr;
-  for (item = address_list; item != nullptr; item = item->ai_next) {
-    if (item->ai_family == AF_INET && item->ai_socktype == SOCK_DGRAM &&
-        item->ai_protocol == IPPROTO_UDP) {
-      found_addr = item;
-      break;
+                      [[maybe_unused]] const EnqueueFlags flags) {
+    if (bytes.empty()) {
+        return TransportError::None;
     }
-  }
 
-  if (found_addr == nullptr) {
-    logger->critical << "client_connect: No IP address found" << std::flush;
-    throw std::runtime_error("client_connect: No IP address found");
-  }
 
-  struct sockaddr_in* ipv4 = (struct sockaddr_in*)&serverAddr.addr;
-  memcpy(ipv4, found_addr->ai_addr, found_addr->ai_addrlen);
-  ipv4->sin_port = htons(serverInfo.port);
-  serverAddr.addr_len = sizeof(sockaddr_in);
+    const auto conn_it = conn_contexts.find(conn_id);
 
-  freeaddrinfo(address_list);
+    if (conn_it == conn_contexts.end()) {
+        // Invalid connection id
+        return TransportError::InvalidConnContextId;
+    }
 
-  addrKey sa_key;
-  addr_to_key(serverAddr.addr, sa_key);
+    const auto data_ctx_it = conn_it->second->data_contexts.find(data_ctx_id);
+    if (data_ctx_it == conn_it->second->data_contexts.end()) {
+        // Invalid data context id
+        return TransportError::InvalidDataContextId;
+    }
 
-  serverAddr.key = sa_key;
+    ConnData cd;
+    cd.data = bytes;
+    cd.conn_id = conn_id;
+    cd.data_ctx_id = data_ctx_id;
+    cd.priority = priority;
 
-  ++last_conn_id;
-  ++last_stream_id;
+    data_ctx_it->second.tx_data->push(cd, ttl_ms, priority);
 
-  connections.emplace(last_conn_id, ConnectionContext { .addr = serverAddr });
-
-  remote_addrs[sa_key] = {last_conn_id, last_stream_id};
-
-  // Create dequeue
-  dequeue_data_map[last_conn_id][last_stream_id].set_limit(1000);
-
-  // Notify caller that the connection is now ready
-  delegate.on_connection_status(last_conn_id, TransportStatus::Ready);
-
-  running_threads.emplace_back(&UDPTransport::fd_reader, this);
-
-  running_threads.emplace_back(&UDPTransport::fd_writer, this);
-
-  return last_conn_id;
+    return TransportError::None;
 }
 
-TransportConnId
-UDPTransport::connect_server()
-{
-  std::stringstream s_log;
+std::optional<std::vector<uint8_t>> UDPTransport::dequeue(const TransportConnId &conn_id,
+                                                          const DataContextId &data_ctx_id) {
 
-  fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-  if (fd < 0) {
-    s_log << "connect_server: Unable to create socket: " << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
+    const auto conn_it = conn_contexts.find(conn_id);
+    if (conn_it == conn_contexts.end()) {
+        logger->warning << "dequeue: invalid conn_id: " << conn_id
+                        << std::flush;
+        // Invalid context id
+        return std::nullopt;
+    }
 
-  // set for re-use
-  int one = 1;
-  int err =
-    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char*)&one, sizeof(one));
-  if (err != 0) {
-    s_log << "connect_server: setsockopt error: " << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
+    const auto data_ctx_it = conn_it->second->data_contexts.find(data_ctx_id);
+    if (data_ctx_it == conn_it->second->data_contexts.end()) {
+        logger->error << "dequeue: invalid stream for conn_id: " << conn_id
+                      << " data_ctx_id: " << data_ctx_id << std::flush;
 
-  // TODO: Add config for this value
-  size_t snd_rcv_max = 2000000;
-  timeval rcv_timeout { .tv_sec = 0, .tv_usec = 10000 };
+        return std::nullopt;
+    }
 
-  err =
-    setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd_rcv_max, sizeof(snd_rcv_max));
-  if (err != 0) {
-    s_log << "client_connect: Unable to set send buffer size: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
+    if (auto cd = data_ctx_it->second.rx_data.pop()) {
+        return cd.value().data;
+    }
 
-  err =
-    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &snd_rcv_max, sizeof(snd_rcv_max));
-  if (err != 0) {
-    s_log << "client_connect: Unable to set receive buffer size: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
+    return std::nullopt;
+}
 
-  err =
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
-  if (err != 0) {
-    s_log << "client_connect: Unable to set receive timeout: "
-          << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
+TransportConnId UDPTransport::connect_client() {
+    std::stringstream s_log;
+
+    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd == -1) {
+        throw std::runtime_error("socket() failed");
+    }
+
+    size_t snd_rcv_max = 64000;   // TODO: Add config for value
+    timeval rcv_timeout{.tv_sec = 0, .tv_usec = 1000};
+
+    int err =
+            setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd_rcv_max, sizeof(snd_rcv_max));
+    if (err != 0) {
+        s_log << "client_connect: Unable to set send buffer size: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    snd_rcv_max = 1000000; // TODO: Add config for value
+    err =
+            setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &snd_rcv_max, sizeof(snd_rcv_max));
+    if (err != 0) {
+        s_log << "client_connect: Unable to set receive buffer size: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    err =
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
+    if (err != 0) {
+        s_log << "client_connect: Unable to set receive timeout: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
 
 
-  struct sockaddr_in srv_addr;
-  memset((char*)&srv_addr, 0, sizeof(srv_addr));
-  srv_addr.sin_port = htons(serverInfo.port);
-  srv_addr.sin_family = AF_INET;
-  srv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    struct sockaddr_in srvAddr;
+    srvAddr.sin_family = AF_INET;
+    srvAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    srvAddr.sin_port = 0;
+    err = bind(fd, (struct sockaddr *) &srvAddr, sizeof(srvAddr));
+    if (err) {
+        s_log << "client_connect: Unable to bind to socket: " << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
 
-  err = bind(fd, (struct sockaddr*)&srv_addr, sizeof(srv_addr));
-  if (err < 0) {
-    s_log << "connect_server: unable to bind to socket: " << strerror(errno);
-    logger->Log(cantina::LogLevel::Critical, s_log.str());
-    throw std::runtime_error(s_log.str());
-  }
+    std::string sPort = std::to_string(htons(serverInfo.port));
+    struct addrinfo hints = {}, *address_list = NULL;
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    err = getaddrinfo(
+            serverInfo.host_or_ip.c_str(), sPort.c_str(), &hints, &address_list);
+    if (err) {
+        strerror(1);
+        s_log << "client_connect: Unable to resolve remote ip address: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
 
-  logger->info << "connect_server: port: " << serverInfo.port << " fd: " << fd
-               << std::flush;
+    struct addrinfo *item = nullptr, *found_addr = nullptr;
+    for (item = address_list; item != nullptr; item = item->ai_next) {
+        if (item->ai_family == AF_INET && item->ai_socktype == SOCK_DGRAM &&
+            item->ai_protocol == IPPROTO_UDP) {
+            found_addr = item;
+            break;
+        }
+    }
 
-  running_threads.emplace_back(&UDPTransport::fd_reader, this);
-  running_threads.emplace_back(&UDPTransport::fd_writer, this);
+    if (found_addr == nullptr) {
+        logger->critical << "client_connect: No IP address found" << std::flush;
+        throw std::runtime_error("client_connect: No IP address found");
+    }
 
-  return last_conn_id;
+    struct sockaddr_in *ipv4 = (struct sockaddr_in *) &serverAddr.addr;
+    memcpy(ipv4, found_addr->ai_addr, found_addr->ai_addrlen);
+    ipv4->sin_port = htons(serverInfo.port);
+    serverAddr.addr_len = sizeof(sockaddr_in);
+
+    freeaddrinfo(address_list);
+
+    serverAddr.id = create_addr_id(serverAddr.addr);
+
+    ++last_conn_id;
+
+    const auto& [conn_it, _] = conn_contexts.emplace(last_conn_id,
+                                                    std::make_shared<ConnectionContext>());
+
+    auto &conn = *conn_it->second;
+    conn.addr = serverAddr;
+    conn.id = last_conn_id;
+    conn.set_bytes_per_us(16000); // Set to 6Mbps connection rate
+
+    addr_conn_contexts.emplace(serverAddr.id, conn_it->second); // Add to the addr lookup map
+
+    // Notify caller that the connection is now ready
+    delegate.on_connection_status(last_conn_id, TransportStatus::Ready);
+
+    running_threads.emplace_back(&UDPTransport::fd_reader, this);
+
+    running_threads.emplace_back(&UDPTransport::fd_writer, this);
+
+    return last_conn_id;
+}
+
+TransportConnId UDPTransport::connect_server() {
+    std::stringstream s_log;
+
+    fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd < 0) {
+        s_log << "connect_server: Unable to create socket: " << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    // set for re-use
+    int one = 1;
+    int err =
+            setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char *) &one, sizeof(one));
+    if (err != 0) {
+        s_log << "connect_server: setsockopt error: " << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    // TODO: Add config for this value
+    size_t snd_rcv_max = 2000000;
+    timeval rcv_timeout{.tv_sec = 0, .tv_usec = 10000};
+
+    err =
+            setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &snd_rcv_max, sizeof(snd_rcv_max));
+    if (err != 0) {
+        s_log << "client_connect: Unable to set send buffer size: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    err =
+            setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &snd_rcv_max, sizeof(snd_rcv_max));
+    if (err != 0) {
+        s_log << "client_connect: Unable to set receive buffer size: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    err =
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
+    if (err != 0) {
+        s_log << "client_connect: Unable to set receive timeout: "
+              << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+
+    struct sockaddr_in srv_addr;
+    memset((char *) &srv_addr, 0, sizeof(srv_addr));
+    srv_addr.sin_port = htons(serverInfo.port);
+    srv_addr.sin_family = AF_INET;
+    srv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    err = bind(fd, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+    if (err < 0) {
+        s_log << "connect_server: unable to bind to socket: " << strerror(errno);
+        logger->Log(cantina::LogLevel::Critical, s_log.str());
+        throw std::runtime_error(s_log.str());
+    }
+
+    logger->info << "connect_server: port: " << serverInfo.port << " fd: " << fd
+                 << std::flush;
+
+    running_threads.emplace_back(&UDPTransport::fd_reader, this);
+    running_threads.emplace_back(&UDPTransport::fd_writer, this);
+
+    return last_conn_id;
 }

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -178,7 +178,7 @@ namespace qtransport {
         Addr serverAddr;
 
         TransportDelegate &delegate;
-        std::mutex _socket_write_mutex;                        /// Used to sync socket writes
+        std::mutex _send_recv_sync_mutex;                      /// Sync send/recv packets and calculations
         std::mutex _connections_mutex;                         /// Mutex for connections map changes
 
 

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -21,6 +21,7 @@
 #include "transport/safe_queue.h"
 
 namespace qtransport {
+    constexpr size_t UDP_MAX_PACKET_SIZE = 64000;
 
     struct AddrId {
         uint64_t ip_hi;

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -142,6 +142,8 @@ namespace qtransport {
             UdpProtocol::ReportMessage report;       // Report to be sent back to sender upon received report_id change
 
             UdpProtocol::ReportMetrics tx_report_metrics;
+            UdpProtocol::ReportMetrics prev_tx_report_metrics; // Last report
+
 
 
             /*
@@ -174,6 +176,7 @@ namespace qtransport {
 
         TransportDelegate &delegate;
         std::mutex _socket_write_mutex;                        /// Used to sync socket writes
+        std::mutex _connections_mutex;                         /// Mutex for connections map changes
 
 
         TransportConnId last_conn_id{0};

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -154,9 +154,11 @@ namespace qtransport {
 
             double bytes_per_us {6.4};     // Default to 50Mbps
 
-            void set_bytes_per_us(uint32_t Kbps) {
-                const auto bytes_per_sec = (Kbps * 1024) / 8;
-                bytes_per_us = ((Kbps * 1024) / 8) / 1'000'000.0 /* 1 second double value */;
+            void set_bytes_per_us(uint32_t Kbps, bool max_of=false) {
+                const auto bpUs = ((Kbps * 1024) / 8) / 1'000'000.0 /* 1 second double value */;
+                if (!max_of || bpUs > bytes_per_us) {
+                    bytes_per_us = bpUs;
+                }
             }
         };
 

--- a/src/transport_udp_protocol.h
+++ b/src/transport_udp_protocol.h
@@ -1,0 +1,104 @@
+#pragma once
+
+namespace qtransport {
+    namespace UdpProtocol {
+        /* ------------------------------------------------------------------------
+         * Wire messages
+         * ------------------------------------------------------------------------
+         */
+        constexpr uint8_t PROTOCOL_VERSION = 1;
+
+        /**
+         * @brief UDP Protocol Types
+         * @details Each UDP packet is encoded with a common header, which includes a type.
+         */
+        enum class ProtocolType : uint8_t {
+            CONNECT = 0,
+            DISCONNECT = 1,
+            KEEPALIVE = 2,
+            DATA = 3,
+            DATA_DISCARD = 4,
+            REPORT = 5,
+        };
+
+        /**
+         * @brief UDP Protocol Common Header
+         * @brief Every UDP packet starts with this common header. The data that follows is defined by the type
+         */
+        struct CommonHeader {
+            uint8_t version {PROTOCOL_VERSION};       /// Protocol version
+            ProtocolType type;                        /// Indicates this is a peering message
+        };
+
+        /**
+         * @brief Connect Message
+         *
+         * @details UDP Protocol starts off with a connect message. Messages will be discarded by the remote
+         *      until the new connection sends a connect message.
+         */
+        struct ConnectMsg : CommonHeader {
+            ConnectMsg() { type = ProtocolType::CONNECT; }
+
+            uint16_t idle_timeout { 120 };            /// Idle timeout in seconds. Must not be zero
+
+        } __attribute__((__packed__, aligned(1)));
+
+        /**
+         * @brief Disconnect Message
+         *
+         * @details Disconnect notification. Remote will immediately purge/close the active connection
+         */
+        struct DisconnectMsg : CommonHeader {
+            DisconnectMsg() { type = ProtocolType::DISCONNECT; }
+        } __attribute__((__packed__, aligned(1)));
+
+        /**
+         * @brief Keepalive Message
+         *
+         * @details Keepalive message. Sent only when no other messages have been sent in idle_timeout / 3.
+         */
+        struct KeepaliveMsg : CommonHeader {
+            KeepaliveMsg() { type = ProtocolType::KEEPALIVE; }
+        } __attribute__((__packed__, aligned(1)));
+
+        /**
+         * @brief Data Message
+         *
+         * @details Data message. Bytes following the header is the data
+         *
+         * @note Can be either type of DATA or DATA_DISCARD
+         */
+        struct DataMsg : CommonHeader {
+            DataMsg() { type = ProtocolType::DATA; } // Can be either DATA or DATA_DISCARD type
+
+            uint16_t report_id { 0 };           /// Report ID this data applies to
+        } __attribute__((__packed__, aligned(1)));
+
+
+        /**
+         * @brief Report Metrics
+         */
+         struct ReportMetrics {
+
+             uint32_t total_packets { 0 };       /// Total number of packets received
+             uint32_t total_bytes { 0 };         /// Total number of data (sans header) bytes received
+             uint32_t duration_ms { 0 };         /// Duration in milliseconds of time from first to latest packet received
+
+         } __attribute__((__packed__, aligned(1)));
+
+        /**
+         * @brief Report Message
+         *
+         * @details Report message. The remote will send a report message upon
+         */
+        struct ReportMessage : CommonHeader {
+            ReportMessage() { type = ProtocolType::REPORT; }
+
+            uint16_t report_id { 0 };           /// Report ID of this report
+            ReportMetrics metrics;
+
+        } __attribute__((__packed__, aligned(1)));
+
+
+    } // end UdpProtocol namespace
+} // end qtransport namespace

--- a/src/transport_udp_protocol.h
+++ b/src/transport_udp_protocol.h
@@ -14,11 +14,12 @@ namespace qtransport {
          */
         enum class ProtocolType : uint8_t {
             CONNECT = 0,
-            DISCONNECT = 1,
-            KEEPALIVE = 2,
-            DATA = 3,
-            DATA_DISCARD = 4,
-            REPORT = 5,
+            CONNECT_OK = 1,
+            DISCONNECT = 2,
+            KEEPALIVE = 3,
+            DATA = 4,
+            DATA_DISCARD = 5,
+            REPORT = 6,
         };
 
         /**
@@ -41,6 +42,13 @@ namespace qtransport {
 
             uint16_t idle_timeout { 120 };            /// Idle timeout in seconds. Must not be zero
 
+        } __attribute__((__packed__, aligned(1)));
+
+        /**
+         * @brief Connect OK Message
+         */
+        struct ConnectOkMsg : CommonHeader {
+            ConnectOkMsg() { type = ProtocolType::CONNECT_OK; }
         } __attribute__((__packed__, aligned(1)));
 
         /**


### PR DESCRIPTION
Significant refactor to add the following new features:

* Connection establishment - helps with port scanning/dos mitigation
* Connection disconnect - Client disconnect is now signaled to close properly
* Connection idle timeout - If the client or server disappears (e.g., crash), idle timeout
  will clean up the connection. 
* Shipping/pacing transmission to configurable rate per microsecond (applied at the millisecond level). 
* Added report feedback with logging and initial calculation of bandwidth and loss. This will be tuned and adjusted
  based on testing. We can use the feedback report to adjust the shaping/pacing.  
