### PR TITLE
Seattle work week updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(quicr-transport
 target_link_libraries(quicr-transport
     PUBLIC
         cantina::logger
-        picoquic-core)
+        picoquic-core picoquic-log)
 target_include_directories(quicr-transport PUBLIC include src )
 set_target_properties(quicr-transport
         PROPERTIES

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -73,7 +73,7 @@ struct TransportConfig
   const uint32_t time_queue_init_queue_size {1000};     /// Initial queue size to reserve upfront
   const uint32_t time_queue_max_duration {1000};        /// Max duration for the time queue in milliseconds
   const uint32_t time_queue_bucket_interval {1};        /// The bucket interval in milliseconds
-  const uint32_t time_queue_size_rx { 1000 };           /// Receive queue size
+  const uint32_t time_queue_rx_ttl {350};               /// Receive queue size
   bool debug {false};                                   /// Enable debug logging/processing
   const uint64_t quic_cwin_minimum { 131072 };          /// QUIC congestion control minimum size (default is 128k)
   const uint32_t quic_wifi_shadow_rtt_us { 20000 };     /// QUIC wifi shadow RTT in microseconds

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -73,7 +73,7 @@ struct TransportConfig
   const uint32_t time_queue_init_queue_size {1000};     /// Initial queue size to reserve upfront
   const uint32_t time_queue_max_duration {1000};        /// Max duration for the time queue in milliseconds
   const uint32_t time_queue_bucket_interval {1};        /// The bucket interval in milliseconds
-  const uint32_t time_queue_rx_ttl {350};               /// Receive queue size
+  const uint32_t time_queue_rx_ttl {350};               /// Receive queue TTL in milliseconds
   bool debug {false};                                   /// Enable debug logging/processing
   const uint64_t quic_cwin_minimum { 131072 };          /// QUIC congestion control minimum size (default is 128k)
   const uint32_t quic_wifi_shadow_rtt_us { 20000 };     /// QUIC wifi shadow RTT in microseconds

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -73,7 +73,7 @@ struct TransportConfig
   const uint32_t time_queue_init_queue_size {1000};     /// Initial queue size to reserve upfront
   const uint32_t time_queue_max_duration {1000};        /// Max duration for the time queue in milliseconds
   const uint32_t time_queue_bucket_interval {1};        /// The bucket interval in milliseconds
-  const uint32_t time_queue_rx_ttl {350};               /// Receive queue TTL in milliseconds
+  const uint32_t time_queue_rx_size {1000};             /// Receive queue size
   bool debug {false};                                   /// Enable debug logging/processing
   const uint64_t quic_cwin_minimum { 131072 };          /// QUIC congestion control minimum size (default is 128k)
   const uint32_t quic_wifi_shadow_rtt_us { 20000 };     /// QUIC wifi shadow RTT in microseconds

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -14,7 +14,7 @@ ITransport::make_client_transport(const TransportRemote& server,
 
   switch (server.proto) {
     case TransportProtocol::UDP:
-      return std::make_shared<UDPTransport>(server, delegate, false, logger);
+      return std::make_shared<UDPTransport>(server, tcfg, delegate, false, logger);
 
     case TransportProtocol::QUIC:
       return std::make_shared<PicoQuicTransport>(server,
@@ -41,7 +41,7 @@ ITransport::make_server_transport(const TransportRemote& server,
 {
   switch (server.proto) {
     case TransportProtocol::UDP:
-      return std::make_shared<UDPTransport>(server, delegate, true, logger);
+      return std::make_shared<UDPTransport>(server, tcfg, delegate, true, logger);
 
     case TransportProtocol::QUIC:
       return std::make_shared<PicoQuicTransport>(server,

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1439,9 +1439,11 @@ TransportConnId PicoQuicTransport::createClient()
 
     uint64_t current_time = picoquic_current_time();
 
+    /* TODO: Instead of using debug, change to client/server config of the directory
     if (debug) {
         picoquic_set_qlog(quic_ctx, ".");
     }
+    */
 
     picoquic_cnx_t* cnx = picoquic_create_cnx(quic_ctx,
                                               picoquic_null_connection_id,

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1165,7 +1165,12 @@ PicoQuicTransport::on_recv_datagram(DataContext* data_ctx, uint8_t* bytes, size_
     }
 
     std::vector<uint8_t> data(bytes, bytes + length);
-    data_ctx->rx_data->push(std::move(data));
+
+    if (!data_ctx->rx_data->push(std::move(data))) {
+        logger->error << "conn_id: " << data_ctx->conn_id
+                      << " data_ctx_id: " << data_ctx->data_ctx_id
+                      << " RX datagram queue is full" << std::flush;
+    }
 
     if (cbNotifyQueue.size() > 100) {
         logger->info << "on_recv_datagram cbNotifyQueue size"

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1,6 +1,7 @@
 #include "transport_picoquic.h"
 
 #include <picoquic_internal.h>
+#include <autoqlog.h>
 #include <picoquic_utils.h>
 
 #include <arpa/inet.h>
@@ -1438,6 +1439,10 @@ TransportConnId PicoQuicTransport::createClient()
 
     uint64_t current_time = picoquic_current_time();
 
+    if (debug) {
+        picoquic_set_qlog(quic_ctx, ".");
+    }
+
     picoquic_cnx_t* cnx = picoquic_create_cnx(quic_ctx,
                                               picoquic_null_connection_id,
                                               picoquic_null_connection_id,
@@ -1484,7 +1489,6 @@ void PicoQuicTransport::client(const TransportConnId conn_id)
         picoquic_set_callback(conn_ctx->pq_cnx, pq_event_cb, this);
 
         picoquic_enable_keep_alive(conn_ctx->pq_cnx, tconfig.idle_timeout_ms * 500);
-
         ret = picoquic_start_client_cnx(conn_ctx->pq_cnx);
         if (ret < 0) {
             logger->Log(cantina::LogLevel::Error, "Could not activate connection");

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1185,7 +1185,7 @@ PicoQuicTransport::on_recv_datagram(DataContext* data_ctx, uint8_t* bytes, size_
     if (data_ctx->rx_data->size() < 4 || data_ctx->in_data_cb_skip_count > 30) {
         data_ctx->in_data_cb_skip_count = 0;
 
-        if (cbNotifyQueue.push([=, this]() { delegate.on_recv_notify(data_ctx->conn_id, data_ctx->current_stream_id, true); })) {
+        if (!cbNotifyQueue.push([=, this]() { delegate.on_recv_notify(data_ctx->conn_id, data_ctx->current_stream_id, true); })) {
 
             logger->error << "conn_id: " << data_ctx->conn_id
                           << " data_ctx_id: " << data_ctx->data_ctx_id
@@ -1327,7 +1327,7 @@ void PicoQuicTransport::on_recv_stream_bytes(DataContext* data_ctx, uint64_t str
         if (data_ctx->rx_data->size() < 4 || data_ctx->in_data_cb_skip_count > 30) {
             data_ctx->in_data_cb_skip_count = 0;
 
-            if (cbNotifyQueue.push([=, this]() { delegate.on_recv_notify(data_ctx->conn_id,
+            if (!cbNotifyQueue.push([=, this]() { delegate.on_recv_notify(data_ctx->conn_id,
                                                                      data_ctx->data_ctx_id, data_ctx->is_bidir); })) {
                 logger->error << "conn_id: " << data_ctx->conn_id
                               << " data_ctx_id: " << data_ctx->data_ctx_id

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -98,7 +98,8 @@ class PicoQuicTransport : public ITransport
         uint8_t priority {0};
 
         uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
-        std::unique_ptr<safe_queue<bytes_t>> rx_data;        /// Pending objects received from the network
+
+        std::unique_ptr<timeQueue> rx_data;                  /// Pending objects received from the network
         std::unique_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
 
         uint8_t* stream_tx_object {nullptr};                 /// Current object that is being sent as a byte stream

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -99,7 +99,7 @@ class PicoQuicTransport : public ITransport
 
         uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
 
-        std::unique_ptr<timeQueue> rx_data;                  /// Pending objects received from the network
+        std::unique_ptr<safe_queue<bytes_t>> rx_data;        /// Pending objects received from the network
         std::unique_ptr<priority_queue<bytes_t>> tx_data;    /// Pending objects to be written to the network
 
         uint8_t* stream_tx_object {nullptr};                 /// Current object that is being sent as a byte stream

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -298,29 +298,32 @@ bool UDPTransport::send_disconnect(const TransportConnId conn_id, const Addr& ad
     return true;
 }
 
-bool UDPTransport::send_keepalive(const TransportConnId conn_id, const Addr &addr) {
+bool UDPTransport::send_keepalive(ConnectionContext& conn) {
     UdpProtocol::KeepaliveMsg khdr {};
 
-    logger->debug << "conn_id: " << conn_id
+    const auto current_tick = _tick_service->get_ticks(std::chrono::milliseconds(1));
+    khdr.ticks_ms = current_tick - conn.tx_next_report_tick;
+
+    logger->debug << "conn_id: " << conn.id
                   << " send KEEPALIVE" << std::flush;
 
     int numSent = sendto(fd,
                          (uint8_t *)&khdr,
                          sizeof(khdr),
                          0 /*flags*/,
-                         (struct sockaddr *) &addr.addr,
-                         addr.addr_len);
+                         (struct sockaddr *) &conn.addr.addr,
+                         conn.addr.addr_len);
 
 
     if (numSent < 0) {
-        logger->error << "conn_id: " << conn_id
+        logger->error << "conn_id: " << conn.id
                       << " Error sending KEEPALIVE to UDP socket: " << strerror(errno)
                       << std::flush;
 
         return false;
 
     } else if (numSent != sizeof(khdr)) {
-        logger->info << "conn_id: " << conn_id
+        logger->info << "conn_id: " << conn.id
                      << " Failed to send KEEPALIVE message, sent: " << numSent
                      << std::flush;
         return false;
@@ -365,32 +368,34 @@ bool UDPTransport::send_data(ConnectionContext& conn, const ConnData& cd, bool d
     uint8_t data[UDP_MAX_PACKET_SIZE] {0};
 
     if (discard) {
-        dhdr.type = UdpProtocol::ProtocolType::DATA_DISCARD;
+        dhdr.flags.discard = 1;
     }
 
     const auto current_tick = _tick_service->get_ticks(std::chrono::milliseconds(1));
 
-    if (current_tick >= conn.next_report_tick) {
+    if (current_tick >= conn.tx_next_report_tick) {
         // New report ID
         /* Too noisy, uncomment when debugging reports
         logger->debug << "Report change conn_id: " << conn.id
-                      << " previous id: " << conn.report_id
+                      << " previous id: " << conn.tx_report_id
                       << " duration_ms: " << conn.tx_report_metrics.duration_ms
                       << " total_bytes: " << conn.tx_report_metrics.total_bytes
                       << " total_packets: " << conn.tx_report_metrics.total_packets
                       << " curr_tick: " << current_tick
-                      << " prev_report_tick: " << conn.next_report_tick
+                      << " prev_report_tick: " << conn.tx_next_report_tick
                       << std::flush;
         */
 
         conn.prev_tx_report_metrics = conn.tx_report_metrics;
+        conn.tx_report_start_tick = current_tick;
         conn.tx_report_metrics = {};
 
-        conn.report_id++;
-        conn.next_report_tick = current_tick + conn.report_interval_ms;
+        conn.tx_report_id++;
+        conn.tx_next_report_tick = current_tick + conn.tx_report_interval_ms;
     }
 
-    dhdr.report_id = conn.report_id;
+    dhdr.report_id = conn.tx_report_id;
+    dhdr.ticks_ms = current_tick - conn.tx_report_start_tick;
 
     const auto data_len = sizeof(dhdr) + cd.data.size();
     if (data_len > sizeof(data)) {
@@ -487,7 +492,7 @@ void UDPTransport::fd_writer() {
                 // Send keepalive if needed
                 if (conn->last_tx_msg_tick && current_tick - conn->last_tx_msg_tick > conn->ka_interval_ms) {
                     conn->last_tx_msg_tick = current_tick;
-                    send_keepalive(conn_id, conn->addr);
+                    send_keepalive(*conn);
                 }
                 continue;
             }
@@ -498,7 +503,7 @@ void UDPTransport::fd_writer() {
                 // Send keepalive if needed
                 if (conn->last_tx_msg_tick && current_tick - conn->last_tx_msg_tick > conn->ka_interval_ms) {
                     conn->last_tx_msg_tick = current_tick;
-                    send_keepalive(conn_id, conn->addr);
+                    send_keepalive(*conn);
                 }
                 continue; // Data maybe null if queue is polled too fast
             }
@@ -635,7 +640,7 @@ void UDPTransport::fd_reader() {
                         conn.addr = remote_addr;
                         conn.id = last_conn_id;
 
-                        conn.report_interval_ms = tconfig.time_queue_rx_size; // TODO: this temp to set this via UI
+                        conn.tx_report_interval_ms = tconfig.time_queue_rx_size; // TODO: this temp to set this via UI
 
                         conn.last_rx_msg_tick = _tick_service->get_ticks(std::chrono::milliseconds(1));
 
@@ -707,6 +712,11 @@ void UDPTransport::fd_reader() {
             case UdpProtocol::ProtocolType::KEEPALIVE: {
                 if (a_conn_it != addr_conn_contexts.end()) {
                     a_conn_it->second->last_rx_msg_tick = _tick_service->get_ticks(std::chrono::milliseconds(1));
+
+                    UdpProtocol::KeepaliveMsg hdr;
+                    memcpy(&hdr, data, sizeof(hdr));
+
+                    a_conn_it->second->last_rx_hdr_tick = hdr.ticks_ms;
                 }
                 break;
             }
@@ -727,7 +737,7 @@ void UDPTransport::fd_reader() {
 
                     if (loss_pct != 0 && hdr.metrics.total_packets > 20) {
                         logger->info << "Received REPORT conn_id: " << a_conn_it->second->id
-                                     << " report_id: " << hdr.report_id
+                                     << " tx_report_id: " << hdr.report_id
                                      << " duration_ms: " << hdr.metrics.duration_ms
                                      << " (" << a_conn_it->second->prev_tx_report_metrics.duration_ms << ")"
                                      << " total_bytes: " << hdr.metrics.total_bytes
@@ -737,6 +747,7 @@ void UDPTransport::fd_reader() {
                                      << " Kbps: " << Kbps
                                      << " prev_Kbps: " << a_conn_it->second->bytes_per_us * 1'000'000 * 8 / 1024
                                      << " Loss: " << loss_pct << "%"
+                                     << " OTT: " << hdr.metrics.recv_ott_ms << "ms"
                                      << std::flush;
 
                         a_conn_it->second->set_bytes_per_us(Kbps * 0.80);
@@ -759,14 +770,23 @@ void UDPTransport::fd_reader() {
                              || hdr.report_id == 0 || hdr.report_id <= 10 /* wrap likely */)) {
                         /* Too noisy, add back only if debugging reports
                         logger->debug << "conn_id: " << a_conn_it->second->id
-                                     << " New REPORT id: " << hdr.report_id
-                                     << " previous id: " <<  a_conn_it->second->report.report_id
+                                     << " New REPORT id: " << hdr.tx_report_id
+                                     << " previous id: " <<  a_conn_it->second->report.tx_report_id
                                      << std::flush;
                         */
+
+                        int rx_tick = current_tick - (a_conn_it->second->report_rx_start_tick + a_conn_it->second->last_rx_hdr_tick);
+                        if (rx_tick < 0) {
+                            a_conn_it->second->report.metrics.recv_ott_ms = 0;
+                            logger->info << "Network is buffering RX data by " << ~rx_tick << "ms in time" << std::flush;
+                        } else {
+                            a_conn_it->second->report.metrics.recv_ott_ms = rx_tick;
+                        }
 
                         send_report(*a_conn_it->second);
 
                         // Init metrics with this packet/data
+                        a_conn_it->second->report_rx_start_tick = current_tick;
                         a_conn_it->second->report.report_id = hdr.report_id;
                         a_conn_it->second->report.metrics.duration_ms = current_tick - a_conn_it->second->last_rx_msg_tick;
                         a_conn_it->second->report.metrics.total_bytes = rLen;
@@ -780,46 +800,25 @@ void UDPTransport::fd_reader() {
                     }
 
                     a_conn_it->second->last_rx_msg_tick = current_tick;
+                    a_conn_it->second->last_rx_hdr_tick = hdr.ticks_ms;
 
-                    std::vector<uint8_t> buffer(data + sizeof(hdr), data + sizeof(hdr) + rLen);
+                    // Only send data if not set to discard
+                    if (!hdr.flags.discard) {
+                        std::vector<uint8_t> buffer(data + sizeof(hdr), data + sizeof(hdr) + rLen);
 
-                    ConnData cd;
-                    cd.data = buffer;
-                    cd.data_ctx_id = 0; // Currently only implement one data context
-                    cd.conn_id = a_conn_it->second->id;
+                        ConnData cd;
+                        cd.data = buffer;
+                        cd.data_ctx_id = 0; // Currently only implement one data context
+                        cd.conn_id = a_conn_it->second->id;
 
-                    a_conn_it->second->data_contexts[0].rx_data.push(cd);
+                        a_conn_it->second->data_contexts[0].rx_data.push(cd);
 
-                    lock.unlock();
-                    if (a_conn_it->second->data_contexts[0].rx_data.size() < 4) {
-                        delegate.on_recv_notify(cd.conn_id, cd.data_ctx_id);
+                        lock.unlock();
+                        if (a_conn_it->second->data_contexts[0].rx_data.size() < 4) {
+                            delegate.on_recv_notify(cd.conn_id, cd.data_ctx_id);
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                break;
-            }
-            case UdpProtocol::ProtocolType::DATA_DISCARD: {
-                UdpProtocol::DataMsg hdr;
-                memcpy(&hdr, data, sizeof(hdr));
-                rLen -= sizeof(hdr);
-
-                if (a_conn_it != addr_conn_contexts.end()) {
-                    a_conn_it->second->last_rx_msg_tick = _tick_service->get_ticks(std::chrono::milliseconds(1));
-
-                    if (hdr.report_id == 0 || a_conn_it->second->report.report_id != hdr.report_id) {
-
-                        a_conn_it->second->report.report_id = hdr.report_id;
-                        a_conn_it->second->report.metrics.duration_ms = 0;
-                        a_conn_it->second->report.metrics.total_bytes = 0;
-                        a_conn_it->second->report.metrics.total_packets = 0;
-
-                    } else {
-                        a_conn_it->second->report.metrics.duration_ms += current_tick - a_conn_it->second->last_rx_msg_tick;
-                        a_conn_it->second->report.metrics.total_bytes += rLen;
-                        a_conn_it->second->report.metrics.total_packets++;
-                    }
-
-                    a_conn_it->second->last_rx_msg_tick = current_tick;
                 }
                 break;
             }
@@ -999,7 +998,7 @@ TransportConnId UDPTransport::connect_client() {
     conn.addr = serverAddr;
     conn.id = last_conn_id;
 
-    conn.report_interval_ms = tconfig.time_queue_rx_size; // TODO: this temp to set this via UI
+    conn.tx_report_interval_ms = tconfig.time_queue_rx_size; // TODO: this temp to set this via UI
 
     conn.set_bytes_per_us(16000); // Set to 16Mbps connection rate
 

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -88,7 +88,7 @@ DataContextId UDPTransport::createDataContext(const qtransport::TransportConnId 
     if (is_new) {
         data_ctx_it->second.data_ctx_id = data_ctx_id;
         data_ctx_it->second.priority = priority;
-        data_ctx_it->second.rx_data.set_limit(tconfig.time_queue_rx_ttl);
+        data_ctx_it->second.rx_data.set_limit(tconfig.time_queue_rx_size);
         data_ctx_it->second.tx_data = std::make_unique<priority_queue<ConnData>>(tconfig.time_queue_max_duration,
                                                                                  tconfig.time_queue_bucket_interval,
                                                                                  _tick_service,
@@ -635,7 +635,7 @@ void UDPTransport::fd_reader() {
                         conn.addr = remote_addr;
                         conn.id = last_conn_id;
 
-                        conn.report_interval_ms = tconfig.time_queue_rx_ttl; // TODO: this temp to set this via UI
+                        conn.report_interval_ms = tconfig.time_queue_rx_size; // TODO: this temp to set this via UI
 
                         conn.last_rx_msg_tick = _tick_service->get_ticks(std::chrono::milliseconds(1));
 
@@ -999,7 +999,7 @@ TransportConnId UDPTransport::connect_client() {
     conn.addr = serverAddr;
     conn.id = last_conn_id;
 
-    conn.report_interval_ms = tconfig.time_queue_rx_ttl; // TODO: this temp to set this via UI
+    conn.report_interval_ms = tconfig.time_queue_rx_size; // TODO: this temp to set this via UI
 
     conn.set_bytes_per_us(16000); // Set to 16Mbps connection rate
 

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -53,6 +53,7 @@ namespace qtransport {
     class UDPTransport : public ITransport {
     public:
         UDPTransport(const TransportRemote &server,
+                     const TransportConfig &tcfg,
                      TransportDelegate &delegate,
                      bool isServerMode,
                      const cantina::LoggerPointer &logger);
@@ -236,6 +237,7 @@ namespace qtransport {
 
         TransportRemote serverInfo;
         Addr serverAddr;
+        TransportConfig tconfig;
 
         TransportDelegate &delegate;
         std::mutex _connections_mutex;                         /// Mutex for connections map changes

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -130,6 +130,7 @@ namespace qtransport {
 
             uint64_t last_rx_msg_tick { 0 };            /// Tick value (ms) when last message was received
             uint64_t last_tx_msg_tick { 0 };            /// Tick value (ms) when last message was sent
+            uint16_t last_rx_hdr_tick { 0 };            /// Last received tick from data/keepalive header
 
             /*
              * Received/negotiated config parameters
@@ -140,10 +141,13 @@ namespace qtransport {
             /*
              * Report variables
              */
-            uint16_t report_id {0};                 // Report ID increments on interval. Wrap is okay
-            uint16_t report_interval_ms { 100 };    // Report ID interval in milliseconds
-            uint64_t next_report_tick {0};          // Tick value to start a new report ID
-            UdpProtocol::ReportMessage report;       // Report to be sent back to sender upon received report_id change
+            uint16_t tx_report_id {0};                  // Report ID increments on interval. Wrap is okay
+            uint16_t tx_report_interval_ms { 100 };     // Report ID interval in milliseconds
+            uint64_t tx_report_start_tick { 0 };        // Tick value on report change (new report interval)
+            uint64_t tx_next_report_tick {0};           // Tick value to start a new report ID
+
+            UdpProtocol::ReportMessage report;          // Report to be sent back to sender upon received tx_report_id change
+            uint64_t report_rx_start_tick { 0 };        // Tick value at start of the RX report interval
 
             UdpProtocol::ReportMetrics tx_report_metrics;
             UdpProtocol::ReportMetrics prev_tx_report_metrics; // Last report
@@ -198,12 +202,11 @@ namespace qtransport {
         /**
          * @brief Send UDP protocol keepalive message
          *
-         * @param conn_id       Connection context ID
-         * @param addr          Address to send the message to
+         * @param conn[in,out]      Connection context reference, will be updated
          *
          * @return True if sent, false if not sent/error
          */
-        bool send_keepalive(const TransportConnId conn_id, const Addr& addr);
+        bool send_keepalive(ConnectionContext& conn);
 
         /**
          * @brief Send UDP protocol data message


### PR DESCRIPTION
Tunes UDP pacing, fixes locking, adds latency/one-way trip-time tracking/metric, adds logging when RX and notify queue are full and oldest message is being dropped. 