### PR TITLE
Resolve reset and wait issue

### DIFF
--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -137,7 +137,7 @@ main()
             auto data = bytes(data_buf, data_buf + sizeof(data_buf));
 
             std::vector<MethodTraceItem> trace;
-            const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
+            const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
 
             trace.push_back({"client:publish", start_time});
 
@@ -153,7 +153,7 @@ main()
             }
             else {
                 std::vector<MethodTraceItem> trace;
-                const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
+                const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
 
                 trace.push_back({"client:publish", start_time});
                 client->enqueue(conn_id, server.proto == TransportProtocol::UDP ? 1 : data_ctx_id, std::move(data), std::move(trace));

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1484,6 +1484,11 @@ void PicoQuicTransport::check_conns_for_congestion()
 
         for (auto& [data_ctx_id, data_ctx] : conn_ctx.active_data_contexts) {
 
+            // Skip context that is in reset and wait
+            if (data_ctx.tx_reset_wait_discard) {
+                continue;
+            }
+
             // Don't include control stream in delayed callbacks check. Control stream should be priority 0 or 1
             if (data_ctx.priority >= 2
                     && data_ctx.metrics.tx_delayed_callback - data_ctx.metrics.prev_tx_delayed_callback > 2) {

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -601,7 +601,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
 
         data_ctx_it->second.tx_data->push(std::move(cd), ttl_ms, priority);
 
-        if (! data_ctx_it->second.mark_stream_active) {
+        if (! data_ctx_it->second.mark_stream_active || data_ctx_it->second.tx_reset_wait_discard) {
             data_ctx_it->second.mark_stream_active = true;
 
             picoquic_runner_queue.push([=]() {

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -601,7 +601,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
 
         data_ctx_it->second.tx_data->push(std::move(cd), ttl_ms, priority);
 
-        if (! data_ctx_it->second.mark_stream_active || data_ctx_it->second.tx_reset_wait_discard) {
+        if (! data_ctx_it->second.mark_stream_active) {
             data_ctx_it->second.mark_stream_active = true;
 
             picoquic_runner_queue.push([=]() {
@@ -1078,6 +1078,8 @@ PicoQuicTransport::send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, 
         if (obj.has_value()) {
             data_ctx->metrics.tx_queue_discards++;
         }
+
+        data_ctx->mark_stream_active = false;
 
         return;
     }


### PR DESCRIPTION
Resolves reset and wait issue where streams reset would not start again. 

Updated reset to mark active immediately a stream after reset. This should speed up iframe objects. 

Fixed issue where reset_and_wait streams would trigger congestion still.  