### PR TITLE
Improve BW detection and support per fragment/object pacing

### DIFF
--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -149,6 +149,7 @@ main()
                                 std::move(trace),
                                 1,
                                 350,
+                                0,
                                 encode_flags);
             }
             else {

--- a/include/transport/priority_queue.h
+++ b/include/transport/priority_queue.h
@@ -109,9 +109,9 @@ namespace qtransport {
         /**
          * @brief Get the first object from queue
          *
-         * @return std::nullopt if queue is empty, otherwise reference to object
+         * @return TimeQueueElement<DataType> value from time queue
          */
-        std::optional<DataType> front()
+        TimeQueueElement<DataType> front()
         {
             std::lock_guard<std::mutex> _(_mutex);
 
@@ -119,19 +119,18 @@ namespace qtransport {
                 if (!tqueue || tqueue->empty())
                     continue;
 
-                if (auto obj = tqueue->front())
-                    return *obj;
+                return std::move(tqueue->front());
             }
 
-            return std::nullopt;
+            return {};
         }
 
         /**
          * @brief Get and remove the first object from queue
          *
-         * @return std::nullopt if queue is empty, otherwise reference to object
+         * @return TimeQueueElement<DataType> from time queue
          */
-        std::optional<DataType> pop_front()
+        TimeQueueElement<DataType> pop_front()
         {
             std::lock_guard<std::mutex> _(_mutex);
 
@@ -139,11 +138,10 @@ namespace qtransport {
                 if (!tqueue || tqueue->empty())
                     continue;
 
-                if (auto obj = tqueue->pop_front())
-                    return std::move(*obj);
+                return std::move(tqueue->pop_front());
             }
 
-            return std::nullopt;
+            return {};
         }
 
         /**

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <array>
+#include <iostream>
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -153,16 +154,18 @@ namespace qtransport {
 
         struct queue_value_type
         {
-            queue_value_type(bucket_type& bucket, index_type value_index, tick_type expiry_tick)
+            queue_value_type(bucket_type& bucket, index_type value_index, tick_type expiry_tick, tick_type wait_for_tick)
               : _bucket{ bucket }
               , _value_index{ value_index }
               , _expiry_tick(expiry_tick)
+              , _wait_for_tick(wait_for_tick)
             {
             }
 
             bucket_type& _bucket;
             index_type _value_index;
             tick_type _expiry_tick;
+            tick_type _wait_for_tick;
         };
 
         using queue_type = std::vector<queue_value_type>;
@@ -227,22 +230,32 @@ namespace qtransport {
         /**
          * @brief Pushes a new value onto the queue with a time-to-live.
          *
-         * @param value The value to push onto the queue.
-         * @param ttl   Time to live for an object using the unit of Duration_t
+         * @param value         The value to push onto the queue.
+         * @param ttl           Time to live for an object using the unit of Duration_t
+         * @param delay_ttl     Pop wait Time to live for an object using the unit of Duration_t
+         *                      This will cause pop to be delayed by this TTL value
          *
          * @throws std::invalid_argument If ttl is greater than duration.
          */
-        void push(const T& value, size_t ttl) { internal_push(value, ttl); }
+        void push(const T& value, size_t ttl, size_t delay_ttl=0)
+        {
+            internal_push(value, ttl, delay_ttl);
+        }
 
         /**
          * @brief Pushes a new value onto the queue with a time-to-live.
          *
-         * @param value The value to push onto the queue.
-         * @param ttl   Time to live for an object using the unit of Duration_t
+         * @param value      The value to push onto the queue.
+         * @param ttl        Time to live for an object using the unit of Duration_t
+         * @param delay_ttl  Pop wait Time to live for an object using the unit of Duration_t
+         *                   This will cause pop to be delayed by this TTL value
          *
          * @throws std::invalid_argument If ttl is greater than duration.
          */
-        void push(T&& value, size_t ttl) { internal_push(std::move(value), ttl); }
+        void push(T&& value, size_t ttl, size_t delay_ttl=0)
+        {
+            internal_push(std::move(value), ttl, delay_ttl);
+        }
 
         /**
          * @brief Pop (increment) front
@@ -285,12 +298,17 @@ namespace qtransport {
                 return std::nullopt;
 
             while (_queue_index < _queue.size()) {
-                auto& [bucket, value_index, expiry_tick] = _queue.at(_queue_index);
+                auto& [bucket, value_index, expiry_tick, pop_wait_ttl] = _queue.at(_queue_index);
 
                 if (value_index >= bucket.size() || ticks > expiry_tick) {
                     _queue_index++;
                     continue;
                 }
+
+                if (pop_wait_ttl > ticks) {
+                    return std::nullopt;
+                }
+
                 return bucket.at(value_index);
             }
 
@@ -351,13 +369,15 @@ namespace qtransport {
          * @details Internal definition of push. Pushes value into specified
          *          bucket, and then emplaces the location info into the queue.
          *
-         * @param value The value to push onto the queue.
-         * @param ttl   Time to live for an object using the unit of Duration_t
+         * @param value         The value to push onto the queue.
+         * @param ttl           Time to live for an object using the unit of Duration_t
+         * @param delay_ttl     Pop wait Time to live for an object using the unit of Duration_t
+         *                      This will cause pop to be delayed by this TTL value
          *
          * @throws std::invalid_argument If ttl is greater than duration.
          */
         template<typename Value>
-        inline void internal_push(Value value, size_t ttl)
+        inline void internal_push(Value value, size_t ttl, size_t delay_ttl)
         {
             if (ttl > _duration) {
                 throw std::invalid_argument("TTL is greater than max duration");
@@ -376,7 +396,7 @@ namespace qtransport {
             bucket_type& bucket = _buckets[future_index];
 
             bucket.push_back(value);
-            _queue.emplace_back(bucket, bucket.size() - 1, expiry_tick);
+            _queue.emplace_back(bucket, bucket.size() - 1, expiry_tick, ticks + delay_ttl);
         }
 
       private:

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -89,8 +89,8 @@ struct TransportConfig
 using time_stamp_us = std::chrono::time_point<std::chrono::steady_clock, std::chrono::microseconds>;
 
 struct MethodTraceItem {
-    const std::string method;                   /// Name of the method
-    const time_stamp_us start_time;             /// Original start time of the call
+    std::string method;                   /// Name of the method
+    time_stamp_us start_time;             /// Original start time of the call
     uint32_t delta;                             /// Delta is calculated based on start_time and now time of constructor
 
     MethodTraceItem() :

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -319,6 +319,7 @@ public:
    * @param[in] bytes		Data to send/write
    * @param[in] priority    Priority of the object, range should be 0 - 255
    * @param[in] ttl_ms      The age the object should exist in queue in milliseconds
+   * @param[in] delay_ms    Delay the pop by millisecond value
    * @param[in] trace       Method time trace vector
    * @param[in] flags       Flags for stream and queue handling on enqueue of object
    *
@@ -330,6 +331,7 @@ public:
                                  std::vector<qtransport::MethodTraceItem> &&trace = { MethodTraceItem{} },
                                  const uint8_t priority = 1,
                                  const uint32_t ttl_ms=350,
+                                 const uint32_t delay_ms=0,
                                  const EnqueueFlags flags={false, false, false}) = 0;
 
   /**

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -549,6 +549,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
                            std::vector<qtransport::MethodTraceItem> &&trace,
                            const uint8_t priority,
                            const uint32_t ttl_ms,
+                           const uint32_t delay_ms,
                            const EnqueueFlags flags)
 {
     if (bytes.empty()) {
@@ -582,7 +583,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
                       std::move(bytes),
                       std::move(trace)};
 
-        conn_ctx_it->second.default_data_context.tx_data->push(std::move(cd), ttl_ms, priority);
+        conn_ctx_it->second.default_data_context.tx_data->push(std::move(cd), ttl_ms, priority, delay_ms);
 
         if (!conn_ctx_it->second.default_data_context.mark_dgram_ready) {
             conn_ctx_it->second.default_data_context.mark_dgram_ready = true;
@@ -620,7 +621,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
                       std::move(bytes),
                       std::move(trace)};
 
-        data_ctx_it->second.tx_data->push(std::move(cd), ttl_ms, priority);
+        data_ctx_it->second.tx_data->push(std::move(cd), ttl_ms, priority, delay_ms);
 
         if (! data_ctx_it->second.mark_stream_active) {
             data_ctx_it->second.mark_stream_active = true;
@@ -979,7 +980,7 @@ PicoQuicTransport::send_next_datagram(DataContext* data_ctx, uint8_t* bytes_ctx,
 
             out_data->trace.push_back({"transport_quic:send_dgram", out_data->trace.front().start_time});
 
-            if (out_data->trace.back().delta > 15000) {
+            if (out_data->trace.back().delta > 60000) {
                 logger->info << "MethodTrace conn_id: " << data_ctx->conn_id
                              << " data_ctx_id: " << data_ctx->data_ctx_id
                              << " priority: " << static_cast<int>(out_data->priority);

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -202,7 +202,7 @@ int pq_event_cb(picoquic_cnx_t* pq_cnx,
         }
 
         case picoquic_callback_stream_reset: {
-            transport->logger->info << "Received RESET stream conn_id: " << conn_id
+            transport->logger->debug << "Received RESET stream conn_id: " << conn_id
                                     << " stream_id: " << stream_id
                                     << std::flush;
 
@@ -224,7 +224,7 @@ int pq_event_cb(picoquic_cnx_t* pq_cnx,
                 data_ctx->stream_rx_buffer.erase(rx_buf_it);
             }
 
-            transport->logger->info << "Received RESET stream; conn_id: " << data_ctx->conn_id
+            transport->logger->debug << "Received RESET stream; conn_id: " << data_ctx->conn_id
                                     << " data_ctx_id: " << data_ctx->data_ctx_id
                                     << " stream_id: " << stream_id
                                     << " RX buf drops: " << data_ctx->metrics.rx_buffer_drops << std::flush;
@@ -1072,7 +1072,7 @@ PicoQuicTransport::send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, 
 
             close_stream(*conn_ctx, data_ctx, true);
 
-            logger->info << "Replacing stream using RESET; conn_id: " << data_ctx->conn_id
+            logger->debug << "Replacing stream using RESET; conn_id: " << data_ctx->conn_id
                          << " data_ctx_id: " << data_ctx->data_ctx_id
                          << " existing_stream: " << existing_stream_id
                          << " write buf drops: " << data_ctx->metrics.tx_buffer_drops
@@ -1851,7 +1851,7 @@ void PicoQuicTransport::create_stream(ConnectionContext& conn_ctx, DataContext *
     conn_ctx.last_stream_id = ::get_next_stream_id(conn_ctx.last_stream_id ,
                                                    _is_server_mode, !data_ctx->is_bidir);
 
-    logger->info << "conn_id: " << conn_ctx.conn_id << " data_ctx_id: " << data_ctx->data_ctx_id
+    logger->debug << "conn_id: " << conn_ctx.conn_id << " data_ctx_id: " << data_ctx->data_ctx_id
                  << " create new stream with stream_id: " << conn_ctx.last_stream_id
                  << std::flush;
 
@@ -1882,12 +1882,12 @@ void PicoQuicTransport::close_stream(const ConnectionContext& conn_ctx, DataCont
         return; // stream already closed
     }
 
-    logger->info << "conn_id: " << conn_ctx.conn_id << " data_ctx_id: " << data_ctx->data_ctx_id
+    logger->debug << "conn_id: " << conn_ctx.conn_id << " data_ctx_id: " << data_ctx->data_ctx_id
                  << " closing stream stream_id: " << data_ctx->current_stream_id
                  << std::flush;
 
     if (send_reset) {
-        logger->info << "Reset stream_id: " << data_ctx->current_stream_id << " conn_id: " << conn_ctx.conn_id
+        logger->debug << "Reset stream_id: " << data_ctx->current_stream_id << " conn_id: " << conn_ctx.conn_id
                      << std::flush;
 
         picoquic_set_app_stream_ctx(conn_ctx.pq_cnx, data_ctx->current_stream_id , NULL);

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -549,7 +549,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
                            std::vector<qtransport::MethodTraceItem> &&trace,
                            const uint8_t priority,
                            const uint32_t ttl_ms,
-                           const uint32_t delay_ms,
+                           [[maybe_unused]] const uint32_t delay_ms,
                            const EnqueueFlags flags)
 {
     if (bytes.empty()) {
@@ -621,7 +621,7 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
                       std::move(bytes),
                       std::move(trace)};
 
-        data_ctx_it->second.tx_data->push(std::move(cd), ttl_ms, priority, delay_ms);
+        data_ctx_it->second.tx_data->push(std::move(cd), ttl_ms, priority, 0);
 
         if (! data_ctx_it->second.mark_stream_active) {
             data_ctx_it->second.mark_stream_active = true;

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -288,6 +288,7 @@ class PicoQuicTransport : public ITransport
                            std::vector<qtransport::MethodTraceItem> &&trace,
                            const uint8_t priority,
                            const uint32_t ttl_ms,
+                           const uint32_t delay_ms,
                            const EnqueueFlags flags) override;
 
     std::optional<std::vector<uint8_t>> dequeue(

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -63,6 +63,7 @@ class PicoQuicTransport : public ITransport
         uint64_t rx_buffer_drops {0};                       /// count of receive buffer drops of data due to RESET request
         uint64_t tx_buffer_drops{0};                        /// Count of write buffer drops of data due to RESET request
         uint64_t tx_queue_discards {0};                     /// Number of objects discarded due to TTL expiry or clear
+        uint64_t tx_queue_expired {0};                      /// Number of objects expired before pop/front
         uint64_t tx_delayed_callback {0};                   /// Count of times transmit callbacks were delayed
         uint64_t prev_tx_delayed_callback {0};              /// Previous transmit delayed callback value, set each interval
         uint64_t tx_reset_wait {0};                         /// Number of times data context performed a reset and wait

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -113,6 +113,7 @@ namespace qtransport {
             DataContextId data_ctx_id{0};
             uint8_t priority {10};
 
+            uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
             safe_queue<ConnData> rx_data;
             std::unique_ptr<priority_queue<ConnData>> tx_data;
         };
@@ -249,7 +250,8 @@ namespace qtransport {
         TransportConfig tconfig;
 
         TransportDelegate &delegate;
-        std::mutex _connections_mutex;                         /// Mutex for connections map changes
+        std::mutex _writer_mutex;                              /// Mutex for writer
+        std::mutex _reader_mutex;                              /// Mutex for reader
 
         TransportConnId last_conn_id{0};
         std::map<TransportConnId, std::shared_ptr<ConnectionContext>> conn_contexts;

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -114,6 +114,8 @@ namespace qtransport {
             uint8_t priority {10};
 
             uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
+            uint64_t tx_queue_expired {0};                       /// Number of objects expired before pop/front
+
             safe_queue<ConnData> rx_data;
             std::unique_ptr<priority_queue<ConnData>> tx_data;
         };


### PR DESCRIPTION
Updates the ALG used for bandwidth detection and pacing decrease and increases. 

Adds expired pop/front metrics and logs for messages dropped by the time queue due to TTL expired upon next pop/front. 

Adds per object (includes fragment) delay pacing to smoothen iframe (large object) bursts. Currently it's only applied to UDP and datagram messages with a 30ms spacing.  Will update API to indicate object pacing.