### PR TITLE
Implementation of stream buffer to support MOQT header/message parsing

### DIFF
--- a/include/transport/stream_buffer.h
+++ b/include/transport/stream_buffer.h
@@ -5,6 +5,7 @@
 #include <deque>
 #include <mutex>
 #include <span>
+#include <optional>
 
 #include <transport/uintvar.h>
 

--- a/include/transport/stream_buffer.h
+++ b/include/transport/stream_buffer.h
@@ -1,15 +1,15 @@
 #pragma once
 
 #include <iostream>
-#include <deque>
 #include <iterator>
+#include <list>
 #include <span>
 
 namespace qtransport {
     template <typename T, class Allocator = std::allocator<T>>
     class stream_buffer
     {
-        using buffer_t = std::deque<T, Allocator>;
+        using buffer_t = std::list<T, Allocator>;
 
     public:
         stream_buffer() = default;
@@ -19,14 +19,22 @@ namespace qtransport {
             return _buffer.empty();
         }
 
-        const T& front() const noexcept
+        std::optional<T> front() noexcept
         {
-            return _buffer.front();
+            if (_buffer_cursor != _buffer.end()) {
+                return *_buffer_cursor;
+            }
+            return std::nullopt;
         }
 
         size_t size() noexcept
         {
-            return std::distance(_buffer_cursor, _buffer.end());
+            return _size;
+        }
+
+        size_t actual_size() noexcept
+        {
+            return _buffer.size();
         }
 
         std::vector<T> front(std::uint16_t length) const noexcept
@@ -48,7 +56,10 @@ namespace qtransport {
                 update_cursor = true;
             }
 
+            purge();
             _buffer.push_back(value);
+            _size++;
+
 
             if (update_cursor) {
                 _buffer_cursor = _buffer.begin();
@@ -62,7 +73,9 @@ namespace qtransport {
                 update_cursor = true;
             }
 
+            purge();
             _buffer.push_back(std::move(value));
+            _size++;
 
             if (update_cursor) {
                 _buffer_cursor = _buffer.begin();
@@ -76,7 +89,9 @@ namespace qtransport {
                 update_cursor = true;
             }
 
+            purge();
             _buffer.insert(_buffer.end(), value.begin(), value.end());
+            _size += value.size();
 
             if (update_cursor) {
                 _buffer_cursor = _buffer.begin();
@@ -90,7 +105,9 @@ namespace qtransport {
                 update_cursor = true;
             }
 
+            purge();
             _buffer.insert(_buffer.end(), value.begin(), value.end());
+            _size += value.size();
 
             if (update_cursor) {
                 _buffer_cursor = _buffer.begin();
@@ -99,17 +116,50 @@ namespace qtransport {
 
         void pop()
         {
-            _buffer_cursor = std::next(_buffer_cursor);
+            next();
         }
 
         void pop(std::uint16_t length)
         {
-            if (size() < length) length = size();
-            _buffer_cursor = std::next(_buffer_cursor, length);
+            next(length);
         }
 
     private:
         buffer_t _buffer;
         buffer_t::iterator _buffer_cursor { _buffer.begin() };
+        int _remove_len {0};
+        int _size {0};
+
+        void next()
+        {
+            next(1);
+        }
+
+        void next(uint16_t len)
+        {
+            if (_buffer_cursor == _buffer.end()) {
+                _remove_len = _size;
+                return;
+            }
+
+            if (len > _size) len = _size;
+
+            if (!len) return;
+
+            _remove_len += len;
+
+            _buffer_cursor = std::next(_buffer_cursor, len);
+        }
+
+        void purge()
+        {
+            //std::cout << "remove_len: " << _remove_len << std::endl;
+            if (_remove_len > 0) {
+                _size -= _remove_len;
+                auto last = std::next(_buffer.begin(), _remove_len);
+                _buffer.erase(_buffer.begin(), last);
+                _remove_len = 0;
+            }
+        }
     };
 }

--- a/include/transport/stream_buffer.h
+++ b/include/transport/stream_buffer.h
@@ -37,10 +37,10 @@ namespace qtransport {
             return std::nullopt;
         }
 
-        std::vector<T> front(std::uint16_t length) noexcept
+        std::vector<T> front(std::uint32_t length) noexcept
         {
 
-            if (_buffer.size()) {
+            if (!_buffer.empty()) {
                 std::lock_guard<std::mutex> _(_rwLock);
 
                 std::vector<T> result(length);
@@ -58,9 +58,9 @@ namespace qtransport {
             }
         }
 
-        void pop(std::uint16_t length)
+        void pop(std::uint32_t length)
         {
-            if (!length || !_buffer.size()) return;
+            if (!length || _buffer.empty()) return;
 
             std::lock_guard<std::mutex> _(_rwLock);
 
@@ -71,7 +71,7 @@ namespace qtransport {
             }
         }
 
-        bool available(std::uint16_t length) const noexcept
+        bool available(std::uint32_t length) const noexcept
         {
             return _buffer.size() >= length;
         }

--- a/include/transport/stream_buffer.h
+++ b/include/transport/stream_buffer.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <iostream>
+#include <deque>
+#include <iterator>
+#include <span>
+
+namespace qtransport {
+    template <typename T, class Allocator = std::allocator<T>>
+    class stream_buffer
+    {
+        using buffer_t = std::deque<T, Allocator>;
+
+    public:
+        stream_buffer() = default;
+
+        bool empty() const noexcept
+        {
+            return _buffer.empty();
+        }
+
+        const T& front() const noexcept
+        {
+            return _buffer.front();
+        }
+
+        size_t size() noexcept
+        {
+            return std::distance(_buffer_cursor, _buffer.end());
+        }
+
+        std::vector<T> front(std::uint16_t length) const noexcept
+        {
+            std::vector<T> result(length);
+            std::copy_n(_buffer_cursor, length, result.begin());
+            return result;
+        }
+
+        bool available(std::uint16_t length) const noexcept
+        {
+            return _buffer.size() >= length;
+        }
+
+        void push(const T& value)
+        {
+            bool update_cursor = false;
+            if (_buffer_cursor == _buffer.end()) {
+                update_cursor = true;
+            }
+
+            _buffer.push_back(value);
+
+            if (update_cursor) {
+                _buffer_cursor = _buffer.begin();
+            }
+        }
+
+        void push(T&& value)
+        {
+            bool update_cursor = false;
+            if (_buffer_cursor == _buffer.end()) {
+                update_cursor = true;
+            }
+
+            _buffer.push_back(std::move(value));
+
+            if (update_cursor) {
+                _buffer_cursor = _buffer.begin();
+            }
+        }
+
+        void push(std::span<T> value)
+        {
+            bool update_cursor = false;
+            if (_buffer_cursor == _buffer.end()) {
+                update_cursor = true;
+            }
+
+            _buffer.insert(_buffer.end(), value.begin(), value.end());
+
+            if (update_cursor) {
+                _buffer_cursor = _buffer.begin();
+            }
+        }
+
+        void push(std::initializer_list<T> value)
+        {
+            bool update_cursor = false;
+            if (_buffer_cursor == _buffer.end()) {
+                update_cursor = true;
+            }
+
+            _buffer.insert(_buffer.end(), value.begin(), value.end());
+
+            if (update_cursor) {
+                _buffer_cursor = _buffer.begin();
+            }
+        }
+
+        void pop()
+        {
+            _buffer_cursor = std::next(_buffer_cursor);
+        }
+
+        void pop(std::uint16_t length)
+        {
+            if (size() < length) length = size();
+            _buffer_cursor = std::next(_buffer_cursor, length);
+        }
+
+    private:
+        buffer_t _buffer;
+        buffer_t::iterator _buffer_cursor { _buffer.begin() };
+    };
+}

--- a/include/transport/stream_buffer.h
+++ b/include/transport/stream_buffer.h
@@ -115,11 +115,11 @@ namespace qtransport {
             if (const auto uv_msb = front()) {
                 if (available(uintV_size(*uv_msb))) {
                     uint64_t uv_len = uintV_size(*uv_msb);
-                    auto len = to_uint64(front(uv_len));
+                    auto val = to_uint64(front(uv_len));
 
                     pop(uv_len);
 
-                    return len;
+                    return val;
                 }
             }
 

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -10,6 +10,7 @@
 #include <sys/socket.h>
 
 #include <cantina/logger.h>
+#include <transport/uintvar.h>
 #include <transport/safe_queue.h>
 #include <transport/transport_metrics.h>
 
@@ -119,112 +120,6 @@ struct ConnData {
     std::vector<uint8_t> data;
     std::vector<MethodTraceItem> trace;
 };
-
-using uintV_t = std::vector<uint8_t>;
-
-/**
- * @brief Get the byte size from variable length-integer
- *
- * @param uintV_msbbyte     MSB byte of the variable length integer
- *
- * @returns the size in bytes of the variable length integer
- */
- inline uint8_t uintV_size(const uint8_t uintV_msbbyte) {
-     if ((uintV_msbbyte & 0x40) == 0x40) {
-         return 2;
-     } else if ((uintV_msbbyte & 0x80) == 0x80) {
-         return 4;
-     } else if ((uintV_msbbyte & 0xC0) == 0xC0) {
-         return 8;
-     } else {
-         return 1;
-     }
- }
-
-/**
- * @brief Convert uint64_t to Variable-Length Integer
- *
- * @details Encode unsigned 64bit value to shorten wrire format per RFC9000 Section 16 (Variable-Length Integer Encoding)
- *
- * @param value         64bit value to convert
- *
- * @returns vector of encoded bytes or empty vector if value is invalid
- */
- inline uintV_t to_uintV(uint64_t value) {
-    static constexpr uint64_t len_1 =  (static_cast<uint64_t>(-1) << (64 - 6) >> (64 - 6));
-    static constexpr uint64_t len_2 =  (static_cast<uint64_t>(-1) << (64 - 14) >> (64 - 14));
-    static constexpr uint64_t len_4 =  (static_cast<uint64_t>(-1) << (64 - 30) >> (64 - 30));
-
-    uint8_t net_bytes[8] {0};          // Network order bytes
-    uint8_t len {0};                   // Length of bytes encoded
-
-    uint8_t* byte_value = reinterpret_cast<uint8_t *>(&value);
-
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    constexpr std::array<uint8_t, sizeof(uint64_t)> host_order { 0,1,2,3,4,5,6,7 };
-#else
-    constexpr std::array<uint8_t, sizeof(uint64_t)> host_order { 7,6,5,4,3,2,1,0 };
-#endif
-
-   if (byte_value[host_order[0]] & 0xC0) { // Check if invalid
-        return {};
-    }
-
-    if (value > len_4) { // 62 bit encoding (8 bytes)
-        for (int i = 0; i < 8; i++) {
-            net_bytes[i] = byte_value[host_order[i]];
-        }
-        net_bytes[0] |= 0xC0;
-        len = 8;
-    } else if (value > len_2) { // 30 bit encoding (4 bytes)
-        for (int i = 0; i < 4; i++) {
-            net_bytes[i] = byte_value[host_order[i + 4]];
-        }
-        net_bytes[0] |= 0x80;
-        len = 4;
-    } else if (value > len_1) { // 14 bit encoding (2 bytes)
-        net_bytes[0] = byte_value[host_order[6]] | 0x40;
-        net_bytes[1] = byte_value[host_order[7]];
-        len = 2;
-    } else {
-        net_bytes[0] = byte_value[host_order[7]];
-        len = 1;
-    }
-
-    std::vector<uint8_t> encoded_bytes(net_bytes, net_bytes+len);
-    return encoded_bytes;
- }
-
-/**
- * @brief Convert Variable-Length Integer to uint64_t
- *
- * @param uintV             Encoded variable-Length integer
- *
- * @returns uint64_t value of the variable length integer
- */
- inline uint64_t to_uint64(const uintV_t& uintV) {
-     if (uintV.empty()) {
-         return 0;
-     }
-
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    constexpr std::array<uint8_t, sizeof(uint64_t)> host_order { 0,1,2,3,4,5,6,7 };
-#else
-    constexpr std::array<uint8_t, sizeof(uint64_t)> host_order { 7,6,5,4,3,2,1,0 };
-#endif
-    uint64_t value {0};
-    uint8_t* byte_value = reinterpret_cast<uint8_t *>(&value);
-
-    const auto offset = 8 - uintV.size();
-
-    for (size_t i=0; i < uintV.size(); i++) {
-        byte_value[host_order[i + offset]] = uintV[i];
-    }
-
-    byte_value[host_order[offset]] = uintV[0] & 0x3f; // Zero MSB length bits
-
-    return value;
-}
 
 /**
  * @brief ITransport interface

--- a/include/transport/transport_metrics.h
+++ b/include/transport/transport_metrics.h
@@ -33,6 +33,8 @@ namespace qtransport {
             _value_sum += value;
             _value_count++;
 
+            if (_value_count == 0) _value_count = 1;
+
             avg = _value_sum / _value_count;
         }
 

--- a/include/transport/transport_metrics.h
+++ b/include/transport/transport_metrics.h
@@ -15,7 +15,7 @@ namespace qtransport {
         uint64_t avg {0};               /// Average value in period
 
         uint64_t _value_sum {0};        /// Accumulating sum of values in period
-        uint16_t _value_count {0};      /// Number of values in period
+        uint64_t _value_count {0};      /// Number of values in period
 
       auto operator<=>(const MinMaxAvg&) const = default;
 
@@ -33,7 +33,7 @@ namespace qtransport {
             _value_sum += value;
             _value_count++;
 
-            if (_value_count == 0) _value_count = 1;
+            if (!_value_count) _value_count = 1;
 
             avg = _value_sum / _value_count;
         }

--- a/include/transport/uintvar.h
+++ b/include/transport/uintvar.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <vector>
+
+namespace qtransport {
+
+    using uintV_t = std::vector<uint8_t>;
+
+    /**
+     * @brief Get the byte size from variable length-integer
+     *
+     * @param uintV_msbbyte     MSB byte of the variable length integer
+     *
+     * @returns the size in bytes of the variable length integer
+     */
+    inline uint8_t uintV_size(const uint8_t uintV_msbbyte)
+    {
+        if ((uintV_msbbyte & 0x40) == 0x40) {
+            return 2;
+        } else if ((uintV_msbbyte & 0x80) == 0x80) {
+            return 4;
+        } else if ((uintV_msbbyte & 0xC0) == 0xC0) {
+            return 8;
+        } else {
+            return 1;
+        }
+    }
+
+    /**
+     * @brief Convert uint64_t to Variable-Length Integer
+     *
+     * @details Encode unsigned 64bit value to shorten wrire format per RFC9000 Section 16 (Variable-Length Integer
+     * Encoding)
+     *
+     * @param value         64bit value to convert
+     *
+     * @returns vector of encoded bytes or empty vector if value is invalid
+     */
+    inline uintV_t to_uintV(uint64_t value)
+    {
+        static constexpr uint64_t len_1 = (static_cast<uint64_t>(-1) << (64 - 6) >> (64 - 6));
+        static constexpr uint64_t len_2 = (static_cast<uint64_t>(-1) << (64 - 14) >> (64 - 14));
+        static constexpr uint64_t len_4 = (static_cast<uint64_t>(-1) << (64 - 30) >> (64 - 30));
+
+        uint8_t net_bytes[8]{ 0 }; // Network order bytes
+        uint8_t len{ 0 };          // Length of bytes encoded
+
+        uint8_t* byte_value = reinterpret_cast<uint8_t*>(&value);
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        constexpr std::array<uint8_t, sizeof(uint64_t)> host_order{ 0, 1, 2, 3, 4, 5, 6, 7 };
+#else
+        constexpr std::array<uint8_t, sizeof(uint64_t)> host_order{ 7, 6, 5, 4, 3, 2, 1, 0 };
+#endif
+
+        if (byte_value[host_order[0]] & 0xC0) { // Check if invalid
+            return {};
+        }
+
+        if (value > len_4) { // 62 bit encoding (8 bytes)
+            for (int i = 0; i < 8; i++) {
+                net_bytes[i] = byte_value[host_order[i]];
+            }
+            net_bytes[0] |= 0xC0;
+            len = 8;
+        } else if (value > len_2) { // 30 bit encoding (4 bytes)
+            for (int i = 0; i < 4; i++) {
+                net_bytes[i] = byte_value[host_order[i + 4]];
+            }
+            net_bytes[0] |= 0x80;
+            len = 4;
+        } else if (value > len_1) { // 14 bit encoding (2 bytes)
+            net_bytes[0] = byte_value[host_order[6]] | 0x40;
+            net_bytes[1] = byte_value[host_order[7]];
+            len = 2;
+        } else {
+            net_bytes[0] = byte_value[host_order[7]];
+            len = 1;
+        }
+
+        std::vector<uint8_t> encoded_bytes(net_bytes, net_bytes + len);
+        return encoded_bytes;
+    }
+
+    /**
+     * @brief Convert Variable-Length Integer to uint64_t
+     *
+     * @param uintV             Encoded variable-Length integer
+     *
+     * @returns uint64_t value of the variable length integer
+     */
+    inline uint64_t to_uint64(const uintV_t& uintV)
+    {
+        if (uintV.empty()) {
+            return 0;
+        }
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        constexpr std::array<uint8_t, sizeof(uint64_t)> host_order{ 0, 1, 2, 3, 4, 5, 6, 7 };
+#else
+        constexpr std::array<uint8_t, sizeof(uint64_t)> host_order{ 7, 6, 5, 4, 3, 2, 1, 0 };
+#endif
+        uint64_t value{ 0 };
+        uint8_t* byte_value = reinterpret_cast<uint8_t*>(&value);
+
+        const auto offset = 8 - uintV.size();
+
+        for (size_t i = 0; i < uintV.size(); i++) {
+            byte_value[host_order[i + offset]] = uintV[i];
+        }
+
+        byte_value[host_order[offset]] = uintV[0] & 0x3f; // Zero MSB length bits
+
+        return value;
+    }
+
+} // namespace qtransport

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1581,15 +1581,18 @@ void PicoQuicTransport::on_recv_stream_bytes(ConnectionContext* conn_ctx,
 
 void PicoQuicTransport::emit_metrics()
 {
-    if (!metrics_data_samples || !metrics_conn_samples) return;
-
     for (auto& [conn_id, conn_ctx] : conn_context) {
         const auto sample_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
 
-        metrics_conn_samples->push({sample_time, conn_id, conn_ctx.metrics});
+        if (metrics_conn_samples) {
+            metrics_conn_samples->push({ sample_time, conn_id, conn_ctx.metrics });
+        }
 
         for (auto& [data_ctx_id, data_ctx] : conn_ctx.active_data_contexts) {
-            metrics_data_samples->push({sample_time, conn_id, data_ctx_id, data_ctx.metrics});
+
+            if (metrics_data_samples) {
+                metrics_data_samples->push({ sample_time, conn_id, data_ctx_id, data_ctx.metrics });
+            }
             data_ctx.metrics.resetPeriod();
         }
 


### PR DESCRIPTION
Moved around uintV_t code a little bit. Had to use locking with stream buffer because there were too many race conditions causing corrupted reads (e.g., duplicates or missing).