### PR TITLE
Implement stream buffer to support MOQT requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 The ObjCrypto Project Authors 
 # SPDX-License-Identifier: BSD-2-Clause
 
+cmake-*
+
 # documentaton web site
 site/
 

--- a/cmd/CMakeLists.txt
+++ b/cmd/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(server echoServer.cc)
+add_executable(server echoServer.cc object.cpp)
 target_link_libraries(server PRIVATE cantina::logger quicr-transport)
 
 target_compile_options(server
@@ -12,7 +12,7 @@ set_target_properties(server
         CXX_EXTENSIONS ON)
 
 
-add_executable(client client.cc)
+add_executable(client client.cc object.cpp)
 target_link_libraries(client PRIVATE cantina::logger quicr-transport)
 
 target_compile_options(client

--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -52,11 +52,12 @@ struct Delegate : public ITransport::TransportDelegate
 
         while (true) {
             if (stream_buf->available(4)) {
-                uint32_t* msg_len = (uint32_t*)stream_buf->front(4).data();
+                auto msg_len_b = stream_buf->front(4);
+                auto* msg_len = reinterpret_cast<uint32_t*>(msg_len_b.data());
 
-                if (stream_buf->available(4 + *msg_len)) {
-                    auto obj = stream_buf->front(4 + *msg_len);
-                    stream_buf->pop(4 + *msg_len);
+                if (stream_buf->available(*msg_len)) {
+                    auto obj = stream_buf->front(*msg_len);
+                    stream_buf->pop(*msg_len);
 
                     _rx_object.process(conn_id, data_ctx_id, obj);
                 } else {

--- a/cmd/echoServer.cc
+++ b/cmd/echoServer.cc
@@ -59,7 +59,7 @@ struct Delegate : public ITransport::TransportDelegate
                 if (!len_b.size())
                     return;
 
-                uint32_t* msg_len = (uint32_t*)len_b.data();
+                auto* msg_len = reinterpret_cast<uint32_t*>(len_b.data());
 
                 if (stream_buf->available(*msg_len)) {
                     auto obj = stream_buf->front(*msg_len);
@@ -67,7 +67,7 @@ struct Delegate : public ITransport::TransportDelegate
 
                     _object.process(conn_id, data_ctx_id, obj);
 
-                    server->enqueue(conn_id, out_data_ctx, std::move(obj));
+                    server->enqueue(conn_id, out_data_ctx, std::move(obj), { MethodTraceItem{} }, 2, 500, 0, { true, false, false, false });
                 } else {
                     break;
                 }

--- a/cmd/object.cpp
+++ b/cmd/object.cpp
@@ -13,7 +13,7 @@ void Object::process(TransportConnId conn_id, std::optional<DataContextId> data_
     if (msg_num == nullptr)
         return;
 
-    if (prev_msg_num && (*msg_num - prev_msg_num) > 1) {
+    if (prev_msg_num && ((*msg_num - prev_msg_num) > 1 || (*msg_num - prev_msg_num) < 0)) {
         logger->info << "GAP: conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : -1)
                      << " msg_len: " << *msg_len
                      << " length: " << obj.size() << " RecvMsg (" << msgcount << ")"

--- a/cmd/object.cpp
+++ b/cmd/object.cpp
@@ -1,0 +1,44 @@
+#include "object.h"
+
+void Object::process(TransportConnId conn_id, std::optional<DataContextId> data_ctx_id, std::vector<uint8_t>& obj) {
+    msgcount++;
+
+    if (msgcount % 2000 == 0 && prev_msgcount != msgcount) {
+        prev_msgcount = msgcount;
+    }
+
+    uint32_t* msg_len = (uint32_t*)obj.data();
+    uint32_t* msg_num = (uint32_t*)(obj.data() + 4);
+
+    if (msg_num == nullptr)
+        return;
+
+    if (prev_msg_num && (*msg_num - prev_msg_num) > 1) {
+        logger->info << "GAP: conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : -1)
+                     << " msg_len: " << *msg_len
+                     << " length: " << obj.size() << " RecvMsg (" << msgcount << ")"
+                     << " msg_num: " << *msg_num << " prev_num: " << prev_msg_num << "("
+                     << *msg_num - prev_msg_num << ")" << std::flush;
+    }
+
+    if (*msg_num % 2000 == 0) {
+        logger->info << "conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : -1)
+                     << " msg_len: " << *msg_len << " length: " << obj.size() << " RecvMsg (" << msgcount << ")"
+                     << " msg_num: " << *msg_num << " prev_num: " << prev_msg_num << "(" << *msg_num - prev_msg_num
+                     << ")" << std::flush;
+    }
+
+    prev_msg_num = *msg_num;
+}
+
+std::vector<uint8_t> Object::encode() {
+    std::vector<uint8_t> obj(1000, 0);
+
+    uint32_t* len = (uint32_t*)obj.data();
+    uint32_t* num = (uint32_t*)(obj.data() + 4);
+
+    *len = obj.size();
+    *num = ++msg_num;
+
+    return std::move(obj);
+}

--- a/cmd/object.cpp
+++ b/cmd/object.cpp
@@ -14,17 +14,17 @@ void Object::process(TransportConnId conn_id, std::optional<DataContextId> data_
         return;
 
     if (prev_msg_num && ((*msg_num - prev_msg_num) > 1 || (*msg_num - prev_msg_num) < 0)) {
-        logger->info << "GAP: conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : -1)
+        logger->info << "GAP: conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : 0)
                      << " msg_len: " << *msg_len
                      << " length: " << obj.size() << " RecvMsg (" << msgcount << ")"
-                     << " msg_num: " << *msg_num << " prev_num: " << prev_msg_num << "("
+                     << " msg_num: " << *msg_num << " prev_num: " << prev_msg_num << " ("
                      << *msg_num - prev_msg_num << ")" << std::flush;
     }
 
     if (*msg_num % 2000 == 0) {
-        logger->info << "conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : -1)
+        logger->info << "conn_id: " << conn_id << " data_ctx_id: " << (data_ctx_id ? *data_ctx_id : 0)
                      << " msg_len: " << *msg_len << " length: " << obj.size() << " RecvMsg (" << msgcount << ")"
-                     << " msg_num: " << *msg_num << " prev_num: " << prev_msg_num << "(" << *msg_num - prev_msg_num
+                     << " msg_num: " << *msg_num << " prev_num: " << prev_msg_num << " (" << *msg_num - prev_msg_num
                      << ")" << std::flush;
     }
 

--- a/cmd/object.h
+++ b/cmd/object.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <transport/transport.h>
+
+using namespace qtransport;
+
+class Object
+{
+  public:
+    Object(const cantina::LoggerPointer& logger) :
+      logger(std::make_shared<cantina::Logger>("OBJ", logger)) {}
+
+    void process(TransportConnId conn_id, std::optional<DataContextId> data_ctx_id, std::vector<uint8_t>& obj);
+    std::vector<uint8_t> encode();
+
+  private:
+    cantina::LoggerPointer logger;
+
+    uint64_t msgcount{ 0 };
+    uint64_t prev_msgcount{ 0 };
+    uint64_t msg_num { 0 };
+    uint32_t prev_msg_num{ 0 };
+};

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -202,13 +202,11 @@ public:
      * @param[in] conn_id 	Transport context identifier mapped to the connection
      * @param[in] stream_id     Transport stream ID
      * @param[in] data_ctx_id	If known, Data context id that the data was received on
-     * @param[in] stream_buf    Pointer to stream buffer if stream buffer
      * @param[in] is_bidir      True if the message is from a bidirectional stream
      */
     virtual void on_recv_stream(const TransportConnId& conn_id,
                                 uint64_t stream_id,
                                 std::optional<DataContextId> data_ctx_id,
-                                std::shared_ptr<StreamBuffer<uint8_t>> stream_buf,
                                 const bool is_bidir=false) = 0;
 
 
@@ -387,14 +385,22 @@ public:
    * @details Data received by the transport will be queued and made available
    * to the caller using this method.  An empty return will be
    *
-   * @param[in] context_id		Identifying the connection
+   * @param[in] conn_id		        Identifying the connection
    * @param[in] data_ctx_id             Data context ID if known
    *
    * @returns std::nullopt if there is no data
    */
-  virtual std::optional<std::vector<uint8_t>> dequeue(TransportConnId context_id,
+  virtual std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
                                                       std::optional<DataContextId> data_ctx_id) = 0;
 
+
+  /**
+   * @brief Similar to dequeue for datagrams this will return a shared pointer to the stream buffer
+   *
+   * @param[in] conn_id		        Identifying the connection
+   * @param[in] stream_id               Stream ID of stream buffer
+   */
+  virtual std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) = 0;
 
    /// Metrics samples to be written to TSDB. When full the buffer will remove the oldest
    std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples;

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -377,7 +377,7 @@ public:
                                  const uint8_t priority = 1,
                                  const uint32_t ttl_ms=350,
                                  const uint32_t delay_ms=0,
-                                 const EnqueueFlags flags={false, false, false, false}) = 0;
+                                 const EnqueueFlags flags={true, false, false, false}) = 0;
 
   /**
    * @brief Dequeue datagram application data from transport buffer

--- a/include/transport/transport_metrics.h
+++ b/include/transport/transport_metrics.h
@@ -69,8 +69,6 @@ namespace qtransport {
         uint64_t tx_timer_losses {0};      /// Packet losses detected due to timer expiring
         uint64_t tx_spurious_losses {0};   /// Number of packet lost that were later acked
 
-        uint64_t dgram_invalid_ctx_id{ 0 }; /// count of datagrams that had a data context that was not known
-
         uint64_t rx_dgrams{ 0 };           /// count of datagrams received
         uint64_t rx_dgrams_bytes{ 0 };     /// Number of receive datagram bytes
 
@@ -100,15 +98,8 @@ namespace qtransport {
     {
         uint64_t enqueued_objs{ 0 };            /// count of objects enqueued by the app to be transmitted
 
-        uint64_t rx_dgrams{ 0 };                /// count of datagrams received
-        uint64_t rx_dgrams_bytes{ 0 };          /// Number of receive datagram bytes
-
-        uint64_t rx_invalid_drops{ 0 };         /// count of times receive data could not be processed due to being invalid
-        uint64_t rx_buffer_drops{ 0 };          /// count of receive buffer drops of data due to RESET request
-
         uint64_t rx_stream_cb{ 0 };             /// count of callbacks to receive data
         uint64_t rx_stream_bytes{ 0 };          /// count of stream bytes received
-        uint64_t rx_stream_objects{ 0 };        /// count of stream objects received
 
         uint64_t tx_buffer_drops{ 0 };          /// Count of write buffer drops of data due to RESET request
         uint64_t tx_queue_discards{ 0 };        /// count of objects discarded due to TTL expiry or clear

--- a/include/transport/transport_metrics.h
+++ b/include/transport/transport_metrics.h
@@ -71,10 +71,14 @@ namespace qtransport {
 
         uint64_t dgram_invalid_ctx_id{ 0 }; /// count of datagrams that had a data context that was not known
 
+        uint64_t rx_dgrams{ 0 };           /// count of datagrams received
+        uint64_t rx_dgrams_bytes{ 0 };     /// Number of receive datagram bytes
+
         uint64_t tx_dgram_cb{ 0 };         /// count of picoquic callback for datagram can be sent
         uint64_t tx_dgram_ack{ 0 };        /// count of picoquic callback for acked datagrams
         uint64_t tx_dgram_lost{ 0 };       /// count of picoquic callback for lost datagrams
         uint64_t tx_dgram_spurious{ 0 };   /// count of picoquic callback for late/delayed dgram acks
+        uint64_t tx_dgram_drops { 0 };     /// count of drops due to data context missing
 
         auto operator<=>(const QuicConnectionMetrics&) const = default;
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -738,16 +738,10 @@ void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
                                              DataContextId data_ctx_id,
                                              uint64_t stream_id) {
 
-    logger->debug << "Set data context to stream conn_id: " << conn_id
-                  << " data_ctx_id: " << data_ctx_id
-                  << " stream_id: " << stream_id
-                  << std::flush;
 
     std::lock_guard<std::mutex> _(_state_mutex);
 
-
     const auto conn_it = conn_context.find(conn_id);
-
     if (conn_it == conn_context.end())
         return;
 
@@ -755,10 +749,15 @@ void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
     if (data_ctx_it == conn_it->second.active_data_contexts.end())
         return;
 
+    logger->debug << "Set data context to stream conn_id: " << conn_id
+                  << " data_ctx_id: " << data_ctx_id
+                  << " stream_id: " << stream_id
+                  << std::flush;
+
     data_ctx_it->second.current_stream_id = stream_id;
 
     picoquic_runner_queue.push([=]() {
-        picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &(*data_ctx_it));
+        picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &data_ctx_it->second);
     });
 }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -764,7 +764,7 @@ void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
 
     picoquic_runner_queue.push([=]() {
         if (conn_it->second.pq_cnx != nullptr)
-            picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &data_ctx_it->second));
+            picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &data_ctx_it->second);
     });
 }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -738,10 +738,16 @@ void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
                                              DataContextId data_ctx_id,
                                              uint64_t stream_id) {
 
+    logger->debug << "Set data context to stream conn_id: " << conn_id
+                  << " data_ctx_id: " << data_ctx_id
+                  << " stream_id: " << stream_id
+                  << std::flush;
 
     std::lock_guard<std::mutex> _(_state_mutex);
 
+
     const auto conn_it = conn_context.find(conn_id);
+
     if (conn_it == conn_context.end())
         return;
 
@@ -757,7 +763,8 @@ void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
     data_ctx_it->second.current_stream_id = stream_id;
 
     picoquic_runner_queue.push([=]() {
-        picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &data_ctx_it->second);
+        if (conn_it->second.pq_cnx != nullptr)
+            picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &(*data_ctx_it));
     });
 }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -764,7 +764,7 @@ void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
 
     picoquic_runner_queue.push([=]() {
         if (conn_it->second.pq_cnx != nullptr)
-            picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &(*data_ctx_it));
+            picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &data_ctx_it->second));
     });
 }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -544,7 +544,7 @@ TransportError
 PicoQuicTransport::enqueue(const TransportConnId& conn_id,
                            const DataContextId& data_ctx_id,
                            std::vector<uint8_t>&& bytes,
-                           std::vector<qtransport::MethodTraceItem> &&trace,
+                           std::vector<MethodTraceItem> &&trace,
                            const uint8_t priority,
                            const uint32_t ttl_ms,
                            [[maybe_unused]] const uint32_t delay_ms,
@@ -737,7 +737,14 @@ void PicoQuicTransport::setRemoteDataCtxId([[maybe_unused]] const TransportConnI
 void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
                                              DataContextId data_ctx_id,
                                              uint64_t stream_id) {
+
+    logger->debug << "Set data context to stream conn_id: " << conn_id
+                  << " data_ctx_id: " << data_ctx_id
+                  << " stream_id: " << stream_id
+                  << std::flush;
+
     std::lock_guard<std::mutex> _(_state_mutex);
+
 
     const auto conn_it = conn_context.find(conn_id);
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -176,6 +176,14 @@ int pq_event_cb(picoquic_cnx_t* pq_cnx,
 
                 if (is_fin) {
                     transport->logger->info << "Received FIN for stream " << stream_id << std::flush;
+
+                    if (auto conn_ctx = transport->getConnContext(conn_id)) {
+                        const auto rx_buf_it = conn_ctx->rx_stream_buffer.find(stream_id);
+                        if (rx_buf_it != conn_ctx->rx_stream_buffer.end()) {
+                            rx_buf_it->second.closed = true;
+                        }
+                    }
+
                 }
             }
 
@@ -189,26 +197,23 @@ int pq_event_cb(picoquic_cnx_t* pq_cnx,
 
             picoquic_reset_stream_ctx(pq_cnx, stream_id);
 
+            if (auto conn_ctx = transport->getConnContext(conn_id)) {
+                const auto rx_buf_it = conn_ctx->rx_stream_buffer.find(stream_id);
+                if (rx_buf_it != conn_ctx->rx_stream_buffer.end()) {
+                    rx_buf_it->second.closed = true;
+                }
+            }
+
             if (data_ctx == NULL) {
                 break;
             }
 
             data_ctx->current_stream_id = std::nullopt;
 
-            const auto rx_buf_it = data_ctx->stream_rx_buffer.find(stream_id);
-            if (rx_buf_it != data_ctx->stream_rx_buffer.end()) {
-                if (rx_buf_it->second.object != nullptr) {
-                    data_ctx->metrics.rx_buffer_drops++;
-                    rx_buf_it->second.reset_buffer();
-                }
-
-                data_ctx->stream_rx_buffer.erase(rx_buf_it);
-            }
-
             transport->logger->debug << "Received RESET stream; conn_id: " << data_ctx->conn_id
                                     << " data_ctx_id: " << data_ctx->data_ctx_id
                                     << " stream_id: " << stream_id
-                                    << " RX buf drops: " << data_ctx->metrics.rx_buffer_drops << std::flush;
+                                    << std::flush;
 
             break;
         }
@@ -362,7 +367,11 @@ int pq_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void
                     transport->pq_loop_prev_time = targ->current_time;
                 }
 
+
                 if (targ->current_time - transport->pq_loop_metrics_prev_time >= METRICS_INTERVAL_US) {
+                    // Use this time to clean up streams that have been closed
+                    transport->remove_closed_streams();
+
                     if (transport->pq_loop_metrics_prev_time) {
                         transport->emit_metrics();
                     }
@@ -612,7 +621,8 @@ PicoQuicTransport::enqueue(const TransportConnId& conn_id,
 }
 
 std::optional<std::vector<uint8_t>>
-PicoQuicTransport::dequeue(const TransportConnId& conn_id, const DataContextId& data_ctx_id)
+PicoQuicTransport::dequeue(TransportConnId conn_id,
+                           [[maybe_unused]] std::optional<DataContextId> data_ctx_id)
 {
     std::lock_guard<std::mutex> _(_state_mutex);
 
@@ -621,15 +631,7 @@ PicoQuicTransport::dequeue(const TransportConnId& conn_id, const DataContextId& 
         return std::nullopt;
     }
 
-    const auto data_ctx_it = conn_ctx_it->second.active_data_contexts.find(data_ctx_id);
-    if (data_ctx_it == conn_ctx_it->second.active_data_contexts.end()) {
-        return std::nullopt;
-    }
-
-    if (auto cd = data_ctx_it->second.rx_data->pop()) {
-        return std::move(cd->data);
-    }
-    return std::nullopt;
+    return conn_ctx_it->second.dgram_rx_data.pop();
 }
 
 DataContextId
@@ -664,7 +666,6 @@ PicoQuicTransport::createDataContext(const TransportConnId conn_id,
 
         data_ctx_it->second.priority = priority;
 
-        data_ctx_it->second.rx_data = std::make_unique<safe_queue<ConnData>>(tconfig.time_queue_rx_size);
         data_ctx_it->second.tx_data = std::make_unique<priority_queue<ConnData>>(tconfig.time_queue_max_duration,
                                                                                 tconfig.time_queue_bucket_interval,
                                                                                 _tick_service,
@@ -690,14 +691,11 @@ PicoQuicTransport::close(const TransportConnId& conn_id)
         return;
 
     // Remove pointer references in picoquic for active streams
-    for (const auto& [d_id, d_ctx]: conn_it->second.active_data_contexts) {
-        if (d_ctx.current_stream_id) {
-            picoquic_mark_active_stream(conn_it->second.pq_cnx, *d_ctx.current_stream_id, 0, NULL);
-            picoquic_reset_stream(conn_it->second.pq_cnx, *d_ctx.current_stream_id, 0);
-        }
+    for (const auto& [stream_id, rx_buf]: conn_it->second.rx_stream_buffer) {
+        picoquic_mark_active_stream(conn_it->second.pq_cnx, stream_id, 0, NULL);
+        picoquic_unlink_app_stream_ctx(conn_it->second.pq_cnx, stream_id);
 
-        for (const auto& [stream_id, _]: d_ctx.stream_rx_buffer) {
-            picoquic_unlink_app_stream_ctx(conn_it->second.pq_cnx, stream_id);
+        if (!rx_buf.closed) {
             picoquic_reset_stream(conn_it->second.pq_cnx, stream_id, 0);
         }
     }
@@ -714,9 +712,15 @@ PicoQuicTransport::close(const TransportConnId& conn_id)
     conn_context.erase(conn_it);
 }
 
-void PicoQuicTransport::setRemoteDataCtxId(const TransportConnId conn_id,
-                                           const DataContextId data_ctx_id,
-                                           const DataContextId remote_data_ctx_id) {
+void PicoQuicTransport::setRemoteDataCtxId([[maybe_unused]] const TransportConnId conn_id,
+                                           [[maybe_unused]] const DataContextId data_ctx_id,
+                                           [[maybe_unused]] const DataContextId remote_data_ctx_id) {
+    return;
+}
+
+void PicoQuicTransport::setStreamIdDataCtxId(const TransportConnId conn_id,
+                                             DataContextId data_ctx_id,
+                                             uint64_t stream_id) {
     std::lock_guard<std::mutex> _(_state_mutex);
 
     const auto conn_it = conn_context.find(conn_id);
@@ -728,11 +732,14 @@ void PicoQuicTransport::setRemoteDataCtxId(const TransportConnId conn_id,
     if (data_ctx_it == conn_it->second.active_data_contexts.end())
         return;
 
-    data_ctx_it->second.data_header.remote_data_ctx_id = remote_data_ctx_id;
-    data_ctx_it->second.data_header.remote_data_ctx_id_V = std::move(to_uintV(remote_data_ctx_id));
+    data_ctx_it->second.current_stream_id = stream_id;
+
+    picoquic_runner_queue.push([=]() {
+        picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &(*data_ctx_it));
+    });
 }
 
-/* ============================================================================
+  /* ============================================================================
  * Public internal methods used by picoquic
  * ============================================================================
  */
@@ -787,6 +794,7 @@ PicoQuicTransport::ConnectionContext& PicoQuicTransport::createConnContext(picoq
     if (is_new) {
         logger->info << "Created new connection context for conn_id: " << conn_ctx.conn_id << std::flush;
 
+        conn_ctx.dgram_rx_data.set_limit(tconfig.time_queue_rx_size);
         conn_ctx.dgram_tx_data = std::make_unique<priority_queue<ConnData>>(tconfig.time_queue_max_duration,
                                                                             tconfig.time_queue_bucket_interval,
                                                                             _tick_service,
@@ -860,7 +868,6 @@ PicoQuicTransport::DataContext* PicoQuicTransport::createDataContextBiDirRecv(Tr
 
         data_ctx_it->second.priority = 10; // TODO: Need to get priority from remote
 
-        data_ctx_it->second.rx_data = std::make_unique<safe_queue<ConnData>>(tconfig.time_queue_rx_size);
         data_ctx_it->second.tx_data = std::make_unique<priority_queue<ConnData>>(tconfig.time_queue_max_duration,
                                                                                 tconfig.time_queue_bucket_interval,
                                                                                 _tick_service,
@@ -911,14 +918,6 @@ void PicoQuicTransport::delete_data_context_internal(TransportConnId conn_id, Da
 
     close_stream(conn_it->second, &data_ctx_it->second, false);
 
-    /*
-     * Clear all received/active streams
-     */
-    for (const auto& [stream_id, _]: data_ctx_it->second.stream_rx_buffer) {
-        picoquic_unlink_app_stream_ctx(conn_it->second.pq_cnx, stream_id);
-        picoquic_reset_stream(conn_it->second.pq_cnx, stream_id, 0);
-    }
-
     conn_it->second.active_data_contexts.erase(data_ctx_it);
 }
 
@@ -948,8 +947,14 @@ PicoQuicTransport::send_next_datagram(ConnectionContext* conn_ctx, uint8_t* byte
     auto out_data = conn_ctx->dgram_tx_data->front();
     if (out_data.has_value) {
         const auto data_ctx_it = conn_ctx->active_data_contexts.find(out_data.value.data_ctx_id);
-        if (data_ctx_it == conn_ctx->active_data_contexts.end())
+        if (data_ctx_it == conn_ctx->active_data_contexts.end()) {
+            logger->warning << "send_next_dgram has no data context conn_id: " << conn_ctx->conn_id
+                            << " data len: " << out_data.value.data.size()
+                            << " dropping"
+                            << std::flush;
+            conn_ctx->metrics.tx_dgram_drops++;
             return;
+        }
 
         check_callback_delta(&data_ctx_it->second);
 
@@ -967,12 +972,7 @@ PicoQuicTransport::send_next_datagram(ConnectionContext* conn_ctx, uint8_t* byte
 
         data_ctx_it->second.metrics.tx_queue_expired += out_data.expired_count;
 
-        data_ctx_it->second.data_header.length_V = std::move(to_uintV(out_data.value.data.size()));
-        const auto data_hdr_size = data_ctx_it->second.data_header.size();
-        const auto data_size = data_hdr_size + out_data.value.data.size();
-
-
-        if (data_size <= max_len) {
+        if (out_data.value.data.size() <= max_len) {
             conn_ctx->dgram_tx_data->pop();
 
             out_data.value.trace.push_back({"transport_quic:send_dgram", out_data.value.trace.front().start_time});
@@ -990,18 +990,17 @@ PicoQuicTransport::send_next_datagram(ConnectionContext* conn_ctx, uint8_t* byte
                 logger->info << " total_duration: " << out_data.value.trace.back().delta << std::flush;
             }
 
-            data_ctx_it->second.metrics.tx_dgrams_bytes += data_size;
+            data_ctx_it->second.metrics.tx_dgrams_bytes += out_data.value.data.size();
             data_ctx_it->second.metrics.tx_dgrams++;
 
             uint8_t* buf = nullptr;
 
             buf = picoquic_provide_datagram_buffer_ex(bytes_ctx,
-                                                      data_size,
+                                                      out_data.value.data.size(),
                                                       conn_ctx->dgram_tx_data->empty() ? picoquic_datagram_not_active : picoquic_datagram_active_any_path);
 
             if (buf != nullptr) {
-                std::memcpy(buf, data_ctx_it->second.data_header.data().data(), data_hdr_size);
-                std::memcpy(buf + data_hdr_size, out_data.value.data.data(), out_data.value.data.size());
+                std::memcpy(buf, out_data.value.data.data(), out_data.value.data.size());
             }
         }
         else {
@@ -1116,33 +1115,7 @@ PicoQuicTransport::send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, 
         return;
     }
 
-
-    auto data_hdr_size = data_ctx->data_header.size();
-
     if (data_ctx->stream_tx_object == nullptr) {
-
-        if (max_len < MAX_DATA_HEADER_SIZE) {
-            // Not enough bytes to send
-            logger->debug << "Not enough bytes to send stream header, waiting for next callback. "
-                          << " conn_id: " << data_ctx->conn_id
-                          << " data_ctx_id: " << data_ctx->data_ctx_id
-                          << " stream_id: " << *data_ctx->current_stream_id
-                          << " priority: " << static_cast<int>(data_ctx->priority)
-                          << *data_ctx->current_stream_id << std::flush;
-
-            mark_stream_active(data_ctx->conn_id, data_ctx->data_ctx_id);
-
-            // TODO: It seems that picoquic will override the above since we didn't actually send data, below schedules it again
-            if (!data_ctx->tx_data->empty()) {
-                data_ctx->mark_stream_active = true;
-                picoquic_runner_queue.push([=]() {
-                    mark_stream_active(data_ctx->conn_id, data_ctx->data_ctx_id);
-                });
-            }
-
-            return;
-        }
-
         auto obj = data_ctx->tx_data->pop_front();
         data_ctx->metrics.tx_queue_expired += obj.expired_count;
 
@@ -1156,11 +1129,7 @@ PicoQuicTransport::send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, 
                 return;
             }
 
-
             data_ctx->metrics.tx_stream_objects++;
-            data_ctx->data_header.length_V = std::move(to_uintV(obj.value.data.size()));
-            data_hdr_size = data_ctx->data_header.size();
-            max_len -= data_hdr_size; // Subtract out the length header that will be added
 
             obj.value.trace.push_back({"transport_quic:send_stream", obj.value.trace.front().start_time});
             data_ctx->metrics.tx_object_duration_us.addValue(obj.value.trace.back().delta);
@@ -1210,29 +1179,20 @@ PicoQuicTransport::send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, 
 
     uint8_t *buf = nullptr;
 
-    if (offset == 0) {
-        // New object being written, add header using little endian for now
-        buf = picoquic_provide_stream_data_buffer(bytes_ctx,
-                                                  data_len + data_hdr_size,
-                                                  0,
-                                                  is_still_active);
-        if (buf != NULL) {
-            std::memcpy(buf, data_ctx->data_header.data().data(), data_hdr_size);
-            buf += data_hdr_size;
-        } else {
-            // Error allocating memory to write
-            return;
-        }
-    } else {
-        buf = picoquic_provide_stream_data_buffer(bytes_ctx,
-                                                  data_len,
-                                                  0,
-                                                  is_still_active);
+    buf = picoquic_provide_stream_data_buffer(bytes_ctx,
+                                              data_len,
+                                              0,
+                                              is_still_active);
 
-        if (buf == NULL) {
-            // Error allocating memory to write
-            return;
-        }
+    if (buf == NULL) {
+        // Error allocating memory to write
+        logger->error << "conn_id: " << data_ctx->conn_id
+                      << " data_ctx_id: " << data_ctx->data_ctx_id
+                      << " priority: " << static_cast<int>(data_ctx->priority)
+                      << " unable to allocate pq buffer size: " << data_len
+                      << std::flush;
+
+        return;
     }
 
     // Write data
@@ -1287,67 +1247,30 @@ PicoQuicTransport::on_recv_datagram(ConnectionContext* conn_ctx, uint8_t* bytes,
         return;
     }
 
-    if (length < bytes[0]) {
-        logger->warning << "DGRAM received and length less than header length; dropping "
-                        << " header_len: " << static_cast<int>(bytes[0])
+    if (conn_ctx == nullptr) {
+        logger->warning << "DGRAM received with NULL connection context; dropping "
                         << " length: " << length
                         << std::flush;
         return;
     }
 
-    std::vector hdr_bytes(bytes, bytes + bytes[0]);
-    DataHeader dhdr {};
-    dhdr.load(std::move(hdr_bytes));
+    std::vector<uint8_t> data(bytes, bytes + length);
 
-    const auto data_ctx_it = conn_ctx->active_data_contexts.find(dhdr.remote_data_ctx_id);
-    if (data_ctx_it == conn_ctx->active_data_contexts.end()) {
-        logger->warning << "DGRAM received and data context id not found; dropping "
-                        << " header_len: " << dhdr.hdr_length
-                        << " data_ctx_id: " << dhdr.remote_data_ctx_id
-                        << " length: " << dhdr.length
-                        << std::flush;
-
-        conn_ctx->metrics.dgram_invalid_ctx_id++;
-        return;
-    }
-
-    std::vector<uint8_t> data(bytes + dhdr.hdr_length, bytes + length);
-
-    std::vector<MethodTraceItem> trace;
-    const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
-
-    trace.push_back({"transport_quic:recv_dgram", start_time});
-
-    ConnData cd { data_ctx_it->second.conn_id, data_ctx_it->second.data_ctx_id,
-                  data_ctx_it->second.priority, std::move(data), std::move(trace)};
-
-    data_ctx_it->second.metrics.rx_dgrams++;
-    data_ctx_it->second.metrics.rx_dgrams_bytes += cd.data.size();
-
-    if (!data_ctx_it->second.rx_data->push(std::move(cd))) {
-        logger->error << "conn_id: " << data_ctx_it->second.conn_id
-                      << " data_ctx_id: " << data_ctx_it->second.data_ctx_id
-                      << " RX datagram queue is full" << std::flush;
-    }
+    conn_ctx->dgram_rx_data.push(std::move(data));
+    conn_ctx->metrics.rx_dgrams++;
+    conn_ctx->metrics.rx_dgrams_bytes += length;
 
     if (cbNotifyQueue.size() > 100) {
         logger->info << "on_recv_datagram cbNotifyQueue size "
                      << cbNotifyQueue.size() << std::flush;
     }
 
-    if (data_ctx_it->second.rx_data->size() < 10 || data_ctx_it->second.in_data_cb_skip_count > 20) {
-        data_ctx_it->second.in_data_cb_skip_count = 0;
+    if (conn_ctx->dgram_rx_data.size() < 10 && !cbNotifyQueue.push([=, this]() {
+            delegate.on_recv_dgram(conn_ctx->conn_id,std::nullopt);
+        })) {
 
-        if (!cbNotifyQueue.push([=, this]() {
-                delegate.on_recv_notify(data_ctx_it->second.conn_id,
-                                        data_ctx_it->second.data_ctx_id, data_ctx_it->second.is_bidir); })) {
-
-            logger->error << "conn_id: " << data_ctx_it->second.conn_id
-                          << " data_ctx_id: " << data_ctx_it->second.data_ctx_id
-                          << " notify queue is full" << std::flush;
-        }
-    } else {
-        data_ctx_it->second.in_data_cb_skip_count++;
+        logger->error << "conn_id: " << conn_ctx->conn_id
+                      << " DGRAM notify queue is full" << std::flush;
     }
 }
 
@@ -1362,220 +1285,26 @@ void PicoQuicTransport::on_recv_stream_bytes(ConnectionContext* conn_ctx,
         return;
     }
 
-    if (data_ctx == NULL)  {
-        if (length < bytes[0]) {
-            logger->error << "New stream received and header length " << static_cast<int>(bytes[0])
-                          << " greater than length " << length
-                          << " conn_id: " << conn_ctx->conn_id
-                          << " stream_id: " << stream_id
-                          << std::flush;
-
-            return;
-        }
-
-        std::vector hdr_bytes(bytes, bytes + bytes[0]);
-        DataHeader dhdr {};
-        dhdr.load(std::move(hdr_bytes));
-
-        if (dhdr.remote_data_ctx_id == 0) {
-            logger->warning << "New stream received with null data context and null data_context_id; dropping "
-                            << " conn_id: " << conn_ctx->conn_id
-                            << " stream_id: " << stream_id
-                            << " header_len: " << dhdr.hdr_length
-                            << " data_ctx_id: " << dhdr.remote_data_ctx_id
-                            << " length: " << dhdr.length
-                            << std::flush;
-            picoquic_reset_stream_ctx(conn_ctx->pq_cnx, stream_id);
-            picoquic_reset_stream(conn_ctx->pq_cnx, stream_id, 0);
-            return;
-        } else {
-            const auto data_ctx_it = conn_ctx->active_data_contexts.find(dhdr.remote_data_ctx_id);
-            if (data_ctx_it == conn_ctx->active_data_contexts.end()) {
-                logger->warning << "Stream received with null data context data ctx id is not found; dropping "
-                                << " conn_id: " << conn_ctx->conn_id
-                                << " stream_id: " << stream_id
-                                << " header_len: " << dhdr.hdr_length
-                                << " data_ctx_id: " << dhdr.remote_data_ctx_id
-                                << " length: " << dhdr.length
-                                << std::flush;
-                close_stream(conn_ctx->pq_cnx, &data_ctx_it->second, true);
-                return;
-            }
-
-            data_ctx = &data_ctx_it->second;
-            data_ctx->data_header = std::move(dhdr);
-            picoquic_set_app_stream_ctx(conn_ctx->pq_cnx, stream_id, data_ctx);
-        }
-    }
-
-    uint8_t *bytes_p = bytes;
-    auto rx_buf_it = data_ctx->stream_rx_buffer.find(stream_id);
-    if (rx_buf_it == data_ctx->stream_rx_buffer.end()) {
-        logger->debug << "Adding received conn_id: " << data_ctx->conn_id
-                     << " data_ctx_id: " << data_ctx->data_ctx_id
+    auto rx_buf_it = conn_ctx->rx_stream_buffer.find(stream_id);
+    if (rx_buf_it == conn_ctx->rx_stream_buffer.end()) {
+        logger->debug << "Adding received conn_id: " << conn_ctx->conn_id
                      << " stream_id: " << stream_id
                      << " into RX buffer" << std::flush;
 
-        auto [it, _] = data_ctx->stream_rx_buffer.try_emplace(stream_id);
+        auto [it, _] = conn_ctx->rx_stream_buffer.try_emplace(stream_id);
         rx_buf_it = it;
     }
 
+    std::span<uint8_t> bytes_a(bytes, length);
     auto &rx_buf = rx_buf_it->second;
 
-    bool object_complete = false;
+    rx_buf.buf->push(bytes_a);
 
-    if (rx_buf.object == nullptr) {
-        if (bytes[0] < 3) {
-            logger->warning << "Stream object header length " << static_cast<int>(bytes[0])
-                            << " is too small " << length
-                            << ". This is invalid and being dropped "
-                            << " conn_id: " << conn_ctx->conn_id
-                            << " stream_id: " << stream_id
-                            << std::flush;
-
-            data_ctx->metrics.rx_invalid_drops++;
-            picoquic_reset_stream(conn_ctx->pq_cnx, stream_id, 0);
-            return;
-        }
-        if (length < bytes[0]) {
-            logger->warning << "Stream object header length " << static_cast<int>(bytes[0])
-                            << " is greater than callback length " << length
-                            << ". This is invalid and being dropped "
-                            << " conn_id: " << conn_ctx->conn_id
-                            << " stream_id: " << stream_id
-                            << std::flush;
-
-            data_ctx->metrics.rx_invalid_drops++;
-            picoquic_reset_stream(conn_ctx->pq_cnx, stream_id, 0);
-            return;
-        }
-
-        std::vector hdr_bytes(bytes, bytes + bytes[0]);
-        DataHeader dhdr {};
-        dhdr.load(std::move(hdr_bytes));
-
-        bytes_p += dhdr.hdr_length;
-        length -= dhdr.hdr_length;
-
-        rx_buf.object_size = dhdr.length;
-
-        if (rx_buf.object_size > 40000000L) { // Safety check
-            logger->warning << "on_recv_stream_bytes stream_id: " << stream_id
-                            << " conn_id: " << data_ctx->conn_id
-                            << " stream_id: " << stream_id
-                            << " data_ctx_id: " << data_ctx->data_ctx_id
-                            << " data length is too large: " << rx_buf.object_size
-                            << std::flush;
-
-            data_ctx->metrics.rx_invalid_drops++;
-            close_stream(conn_ctx->pq_cnx, data_ctx, true);
-            return;
-        }
-
-        if (rx_buf.object_size <= length) {
-            object_complete = true;
-
-            std::vector<uint8_t> data(bytes_p, bytes_p + rx_buf.object_size);
-
-            std::vector<MethodTraceItem> trace;
-            const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
-
-            trace.push_back({"transport_quic:recv_stream", start_time});
-
-            ConnData cd { data_ctx->conn_id, data_ctx->data_ctx_id, data_ctx->priority, std::move(data), std::move(trace)};
-
-            data_ctx->rx_data->push(std::move(cd));
-
-            bytes_p += rx_buf.object_size;
-            length -= rx_buf.object_size;
-
-            data_ctx->metrics.rx_stream_bytes += rx_buf.object_size;
-
-            rx_buf.reset_buffer();
-        }
-        else {
-            // Need to wait for more data, create new object buffer
-            rx_buf.object = new uint8_t[rx_buf.object_size];
-
-            rx_buf.object_offset = length;
-            std::memcpy(rx_buf.object, bytes_p, length);
-            data_ctx->metrics.rx_stream_bytes += length;
-            length = 0; // no more data left to process
-        }
-    }
-    else { // Existing object, append
-        size_t remaining_len = rx_buf.object_size - rx_buf.object_offset;
-
-        if (remaining_len > length) {
-            remaining_len = length;
-            length = 0; // no more data left to process
-
-        } else {
-            object_complete = true;
-            length -= remaining_len;
-        }
-
-        data_ctx->metrics.rx_stream_bytes += remaining_len;
-
-        std::memcpy(rx_buf.object + rx_buf.object_offset, bytes_p, remaining_len);
-        bytes_p += remaining_len;
-
-        if (object_complete) {
-            std::vector<uint8_t> data(rx_buf.object,
-                                      rx_buf.object + rx_buf.object_size);
-
-            std::vector<MethodTraceItem> trace;
-            const auto start_time = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now());
-
-            trace.push_back({"transport_quic:recv_stream", start_time});
-
-            ConnData cd { data_ctx->conn_id, data_ctx->data_ctx_id, data_ctx->priority, std::move(data), std::move(trace)};
-
-            data_ctx->rx_data->push(std::move(cd));
-
-            rx_buf.reset_buffer();
-        }
-        else {
-            rx_buf.object_offset += remaining_len;
-        }
-    }
-
-    if (object_complete) {
-        data_ctx->metrics.rx_stream_objects++;
-
-        if (cbNotifyQueue.size() > 150) {
-            logger->warning << "on_recv_stream_bytes "
-                            << " conn_id: " << data_ctx->conn_id
-                            << " data_ctx_id: " << data_ctx->data_ctx_id
-                            << " cbNotifyQueue size: " << cbNotifyQueue.size()
-                            << std::flush;
-        }
-
-        if (data_ctx->rx_data->size() < 4 || data_ctx->in_data_cb_skip_count > 30) {
-            data_ctx->in_data_cb_skip_count = 0;
-
-            if (!cbNotifyQueue.push([=, this]() { delegate.on_recv_notify(data_ctx->conn_id,
-                                                                          data_ctx->data_ctx_id, data_ctx->is_bidir); })) {
-                logger->error << "conn_id: " << data_ctx->conn_id
-                              << " data_ctx_id: " << data_ctx->data_ctx_id
-                              << " notify queue is full" << std::flush;
-
-            }
-        } else {
-            data_ctx->in_data_cb_skip_count++;
-        }
-    }
-
-    if (length > 0) {
-        logger->debug << "on_recv_stream_bytes has remaining bytes: " << length
-                      << " conn_id: " << data_ctx->conn_id
-                      << " data_ctx_id: " << data_ctx->data_ctx_id
-                      << " stream_id: " << *data_ctx->current_stream_id
-                      << " dhr hdr len: " << static_cast<int>(data_ctx->data_header.hdr_length)
-                      << " dhr size: " << static_cast<int>(data_ctx->data_header.hdr_length)
-                      << std::flush;
-        
-        on_recv_stream_bytes(conn_ctx, data_ctx, stream_id, bytes_p, length);
+    if (data_ctx != nullptr) {
+        data_ctx->metrics.rx_stream_bytes += length;
+        delegate.on_recv_stream(conn_ctx->conn_id, stream_id, data_ctx->data_ctx_id, rx_buf.buf, data_ctx->is_bidir);
+    } else {
+        delegate.on_recv_stream(conn_ctx->conn_id, stream_id, std::nullopt, rx_buf.buf);
     }
 }
 
@@ -1597,6 +1326,25 @@ void PicoQuicTransport::emit_metrics()
         }
 
         conn_ctx.metrics.resetPeriod();
+    }
+}
+
+void PicoQuicTransport::remove_closed_streams() {
+    std::lock_guard<std::mutex> _(_state_mutex);
+
+    std::vector<uint64_t> closed_streams;
+    for (auto& [conn_id, conn_ctx] : conn_context) {
+        std::vector<uint64_t> closed_streams;
+
+        for (const auto& [stream_id, rx_buf]: conn_ctx.rx_stream_buffer) {
+            if (rx_buf.closed && rx_buf.buf->empty()) {
+                closed_streams.push_back(stream_id);
+            }
+        }
+
+        for (const auto stream_id: closed_streams) {
+            conn_ctx.rx_stream_buffer.erase(stream_id);
+        }
     }
 }
 
@@ -1991,7 +1739,7 @@ void PicoQuicTransport::create_stream(ConnectionContext& conn_ctx, DataContext *
 
 }
 
-void PicoQuicTransport::close_stream(const ConnectionContext& conn_ctx, DataContext* data_ctx, const bool send_reset)
+void PicoQuicTransport::close_stream(ConnectionContext& conn_ctx, DataContext* data_ctx, const bool send_reset)
 {
     if (!data_ctx->current_stream_id.has_value()) {
         return; // stream already closed
@@ -2018,7 +1766,14 @@ void PicoQuicTransport::close_stream(const ConnectionContext& conn_ctx, DataCont
     }
 
     data_ctx->reset_tx_object();
-    data_ctx->stream_rx_buffer.erase(*data_ctx->current_stream_id);
+
+    if (data_ctx->current_stream_id) {
+        const auto rx_buf_it = conn_ctx.rx_stream_buffer.find(*data_ctx->current_stream_id);
+        if (rx_buf_it != conn_ctx.rx_stream_buffer.end()) {
+            std::lock_guard<std::mutex> _(_state_mutex);
+            conn_ctx.rx_stream_buffer.erase(rx_buf_it);
+        }
+    }
 
     data_ctx->current_stream_id = std::nullopt;
 }

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -131,6 +131,7 @@ class PicoQuicTransport : public ITransport
          struct RxStreamBuffer {
              std::shared_ptr<StreamBuffer<uint8_t>> buf;
              bool closed { false };                                          /// Indicates if stream is active or in closed state
+             bool checked_once { false };                                    /// True if closed and checked once to close
 
              RxStreamBuffer() {
                  buf = std::make_shared<StreamBuffer<uint8_t>>();
@@ -230,6 +231,8 @@ class PicoQuicTransport : public ITransport
 
     std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
                                                 std::optional<DataContextId> data_ctx_id) override;
+
+    std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) override;
 
     void setRemoteDataCtxId(const TransportConnId conn_id,
                             const DataContextId data_ctx_id,

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -81,12 +81,16 @@ namespace qtransport {
                                const uint32_t delay_ms,
                                const EnqueueFlags flags) override;
 
-        std::optional<std::vector<uint8_t>>
-        dequeue(const TransportConnId &conn_id, const DataContextId &data_ctx_id) override;
+        std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
+                                                    std::optional<DataContextId> data_ctx_id) override;
 
         void setRemoteDataCtxId(const TransportConnId conn_id,
                                 const DataContextId data_ctx_id,
                                 const DataContextId remote_data_ctx_id) override;
+
+        void setStreamIdDataCtxId([[maybe_unused]] const TransportConnId conn_id,
+                                  [[maybe_unused]] DataContextId data_ctx_id,
+                                  [[maybe_unused]] uint64_t stream_id) override {}
 
     private:
         TransportConnId connect_client();

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -84,6 +84,8 @@ namespace qtransport {
         std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
                                                     std::optional<DataContextId> data_ctx_id) override;
 
+        std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) override {}
+
         void setRemoteDataCtxId(const TransportConnId conn_id,
                                 const DataContextId data_ctx_id,
                                 const DataContextId remote_data_ctx_id) override;

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -84,7 +84,7 @@ namespace qtransport {
         std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
                                                     std::optional<DataContextId> data_ctx_id) override;
 
-        std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) override {}
+        std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) override { return nullptr;}
 
         void setRemoteDataCtxId(const TransportConnId conn_id,
                                 const DataContextId data_ctx_id,


### PR DESCRIPTION
MOQT requires per uintvar header parsing, which will have track alias. Track alias is equivalent to data context ID. Unfortunately the transport will not be able to parse this without libquicr (chicken and egg situation). Due to this, MOQT requires a stream of bytes from transport.  Transport looses visibility on mapping which data flow context a new stream belongs to. To mitigate this, libquicr can call `setStreamIdDataCtxId()` to bind a new stream to a data context. This is optional for libquicr. If the binding happens, then metrics will be available at the data context level.  If the mapping does not happen, then metrics will be at the connection level for received data. 

Transmit still has data context and still sends based on libquicr published objects. The main difference is that the transport header does not get added to streams anymore. 

On received notify callback has been changed to use `on_recv_dgram()` and `on_recv_stream()` callbacks. Datagram still has object (e.g., datagram frames) awareness since datagrams require complete objects (complete MOQT message) within each datagram frame. Stream will be delivered based on bytes, which will vary based on several factors. For this reason, a stream buffer of bytes is used to receive bytes on a stream. 

> [!NOTE]
> UDP custom protocol stil has a data header and still works the way it does today. UDP will need to be updated after MOQT QUIC related changes are complete.   

* Resolves #131
