### PR TITLE
Fixup compiler warnings

### DIFF
--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -46,9 +46,9 @@ struct Delegate : public ITransport::TransportDelegate
     void on_recv_stream(const TransportConnId& conn_id,
                         uint64_t stream_id,
                         std::optional<DataContextId> data_ctx_id,
-                        const bool is_bidir)
+                        [[maybe_unused]] const bool is_bidir)
     {
-        auto stream_buf = std::move(client->getStreamBuffer(conn_id, stream_id));
+        auto stream_buf = client->getStreamBuffer(conn_id, stream_id);
 
         while (true) {
             if (stream_buf->available(4)) {

--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -96,8 +96,8 @@ main()
 
     TransportRemote server = TransportRemote{ "127.0.0.1", 1234, TransportProtocol::QUIC };
 
-    TransportConfig tconfig{ .tls_cert_filename = NULL,
-                             .tls_key_filename = NULL,
+    TransportConfig tconfig{ .tls_cert_filename = "",
+                             .tls_key_filename = "",
                              .time_queue_init_queue_size = 1000,
                              .time_queue_max_duration = 1000,
                              .time_queue_bucket_interval = 1,

--- a/cmd/echoServer.cc
+++ b/cmd/echoServer.cc
@@ -17,9 +17,6 @@ struct Delegate : public ITransport::TransportDelegate
 
     Object _object { logger };
 
-    uint64_t msgcount{ 0 };
-    uint64_t prev_msgcount{ 0 };
-    uint32_t prev_msg_num{ 0 };
     DataContextId out_data_ctx{ 0 };
 
   public:
@@ -51,7 +48,7 @@ struct Delegate : public ITransport::TransportDelegate
                         std::optional<DataContextId> data_ctx_id,
                         [[maybe_unused]] const bool is_bidir)
     {
-        auto stream_buf = std::move(server->getStreamBuffer(conn_id, stream_id));
+        auto stream_buf = server->getStreamBuffer(conn_id, stream_id);
 
         while(true) {
             if (stream_buf->available(4)) {

--- a/cmd/object.cpp
+++ b/cmd/object.cpp
@@ -40,5 +40,5 @@ std::vector<uint8_t> Object::encode() {
     *len = obj.size();
     *num = ++msg_num;
 
-    return std::move(obj);
+    return obj;
 }

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -74,8 +74,8 @@ struct TransportRemote
  */
 struct TransportConfig
 {
-  char *tls_cert_filename;                        /// QUIC TLS certificate to use
-  char *tls_key_filename;                         /// QUIC TLS private key to use
+  const char *tls_cert_filename;                  /// QUIC TLS certificate to use
+  const char *tls_key_filename;                   /// QUIC TLS private key to use
   uint32_t time_queue_init_queue_size {1000};     /// Initial queue size to reserve upfront
   uint32_t time_queue_max_duration {1000};        /// Max duration for the time queue in milliseconds
   uint32_t time_queue_bucket_interval {1};        /// The bucket interval in milliseconds
@@ -90,7 +90,7 @@ struct TransportConfig
   uint64_t idle_timeout_ms { 30000 };             /// Idle timeout for transport connection(s) in milliseconds
   bool use_reset_wait_strategy { false };         /// Use Reset and wait strategy for congestion control
   bool use_bbr { true };                          /// Use BBR if true, NewReno if false
-  char* quic_qlog_path;                           /// QUIC LOG file location path, trivially copyable null terminated string
+  const char* quic_qlog_path;                     /// QUIC LOG file location path, trivially copyable null terminated string
   uint8_t quic_priority_limit { 0 };              /// Lowest priority that will not be bypassed from pacing/CC in picoquic
 };
 

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <chrono>
 #include <sys/socket.h>
+#include <string>
 
 #include <cantina/logger.h>
 #include <transport/uintvar.h>
@@ -74,8 +75,8 @@ struct TransportRemote
  */
 struct TransportConfig
 {
-  const char *tls_cert_filename;                  /// QUIC TLS certificate to use
-  const char *tls_key_filename;                   /// QUIC TLS private key to use
+  std::string tls_cert_filename;                  /// QUIC TLS certificate to use
+  std::string tls_key_filename;                   /// QUIC TLS private key to use
   uint32_t time_queue_init_queue_size {1000};     /// Initial queue size to reserve upfront
   uint32_t time_queue_max_duration {1000};        /// Max duration for the time queue in milliseconds
   uint32_t time_queue_bucket_interval {1};        /// The bucket interval in milliseconds
@@ -90,7 +91,7 @@ struct TransportConfig
   uint64_t idle_timeout_ms { 30000 };             /// Idle timeout for transport connection(s) in milliseconds
   bool use_reset_wait_strategy { false };         /// Use Reset and wait strategy for congestion control
   bool use_bbr { true };                          /// Use BBR if true, NewReno if false
-  const char* quic_qlog_path;                     /// QUIC LOG file location path, trivially copyable null terminated string
+  std::string quic_qlog_path;                     /// If present, log QUIC LOG file to this path
   uint8_t quic_priority_limit { 0 };              /// Lowest priority that will not be bypassed from pacing/CC in picoquic
 };
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -522,9 +522,9 @@ PicoQuicTransport::start(std::shared_ptr<safe_queue<MetricsConnSample>> metrics_
         }
     }
 
-    if (tconfig.quic_qlog_path != nullptr) {
+    if (!tconfig.quic_qlog_path.empty()) {
         logger->info << "Enabling qlog using '" << tconfig.quic_qlog_path << "' path" << std::flush;
-        picoquic_set_qlog(quic_ctx, tconfig.quic_qlog_path);
+        picoquic_set_qlog(quic_ctx, tconfig.quic_qlog_path.c_str());
     }
 
     return cid;
@@ -879,13 +879,13 @@ PicoQuicTransport::PicoQuicTransport(const TransportRemote& server,
 
     picoquic_config_init(&config);
 
-    if (_is_server_mode && tcfg.tls_cert_filename == NULL) {
+    if (_is_server_mode && tcfg.tls_cert_filename.empty()) {
         throw InvalidConfigException("Missing cert filename");
-    } else if (tcfg.tls_cert_filename != NULL) {
-        (void)picoquic_config_set_option(&config, picoquic_option_CERT, tcfg.tls_cert_filename);
+    } else if (!tcfg.tls_cert_filename.empty()) {
+        (void)picoquic_config_set_option(&config, picoquic_option_CERT, tcfg.tls_cert_filename.c_str());
 
-        if (tcfg.tls_key_filename != NULL) {
-            (void)picoquic_config_set_option(&config, picoquic_option_KEY, tcfg.tls_key_filename);
+        if (!tcfg.tls_key_filename.empty()) {
+            (void)picoquic_config_set_option(&config, picoquic_option_KEY, tcfg.tls_key_filename.c_str());
         } else {
             throw InvalidConfigException("Missing cert key filename");
         }

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -84,6 +84,7 @@ TransportStatus UDPTransport::status() const {
     } else if (!isServerMode) {
         return clientStatus;
     }
+    return clientStatus;
 }
 
 DataContextId UDPTransport::createDataContext(const qtransport::TransportConnId conn_id,


### PR DESCRIPTION
- Some returns of temporary variables using `std::move` warn about preventing copy-elision. 
- I believe transport config char pointers should be constant (especially due to string literals being used in some places). 
- Non explicit `this` capture is deprecated (maybe only in clang16, but still). 
- Couple of missing returns in non-void functions. 