### PR TITLE
Add ClassCase tidy rule

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: '-*,readability-identifier-naming'
 CheckOptions:
   - { key: readability-identifier-naming.PrivateMemberPrefix, value: _ }
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase }
 WarningsAsErrors: "*"
 HeaderFilterRegex: "(/include/transport|/src)/.*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,8 @@ if (LINT)
   find_program(CLANG_TIDY_EXE clang-tidy REQUIRED)
   set_target_properties(quicr-transport
     PROPERTIES
-      CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+      CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+      CXX_CLANG_TIDY_EXPORT_FIXES_DIR "clang-tidy-fixes")
 endif (LINT)
 
 target_compile_options(quicr-transport

--- a/cmd/client.cc
+++ b/cmd/client.cc
@@ -121,8 +121,8 @@ main()
     d.setClientTransport(client);
     logger->info << "after set client transport client use_count: " << client.use_count() << std::flush;
 
-    auto metrics_conn_samples = std::make_shared<safe_queue<MetricsConnSample>>(10);
-    auto metrics_data_samples = std::make_shared<safe_queue<MetricsDataSample>>(10);
+    auto metrics_conn_samples = std::make_shared<SafeQueue<MetricsConnSample>>(10);
+    auto metrics_data_samples = std::make_shared<SafeQueue<MetricsDataSample>>(10);
 
     auto conn_id = client->start(metrics_conn_samples, metrics_data_samples);
 

--- a/cmd/echoServer.cc
+++ b/cmd/echoServer.cc
@@ -113,8 +113,8 @@ main()
         serverIp.port = atoi(envVar);
 
     auto server = ITransport::make_server_transport(serverIp, tconfig, d, logger);
-    auto metrics_conn_samples = std::make_shared<safe_queue<MetricsConnSample>>(10);
-    auto metrics_data_samples = std::make_shared<safe_queue<MetricsDataSample>>(10);
+    auto metrics_conn_samples = std::make_shared<SafeQueue<MetricsConnSample>>(10);
+    auto metrics_data_samples = std::make_shared<SafeQueue<MetricsDataSample>>(10);
     server->start(metrics_conn_samples, metrics_data_samples);
 
     d.setServerTransport(server);

--- a/include/transport/priority_queue.h
+++ b/include/transport/priority_queue.h
@@ -23,10 +23,10 @@ namespace qtransport {
      * @tparam PMAX       Max priorities to allow - Range becomes 0 - PMAX
      */
     template<typename DataType, uint8_t PMAX = 32>
-    class priority_queue
+    class PriorityQueue
     {
         using timeType = std::chrono::milliseconds;
-        using timeQueue = time_queue<DataType, timeType>;
+        using timeQueue = TimeQueue<DataType, timeType>;
 
         struct Exception : public std::runtime_error
         {
@@ -39,15 +39,15 @@ namespace qtransport {
         };
 
       public:
-        ~priority_queue() {
+        ~PriorityQueue() {
         }
 
         /**
          * Construct a priority queue
          * @param tick_service Shared pointer to tick_service service
          */
-        priority_queue(const std::shared_ptr<tick_service>& tick_service)
-          : priority_queue(1000, 1, _tick_service, 1000)
+        PriorityQueue(const std::shared_ptr<TickService>& tick_service)
+          : PriorityQueue(1000, 1, _tick_service, 1000)
         {
         }
 
@@ -59,9 +59,9 @@ namespace qtransport {
          * @param tick_service          Shared pointer to tick_service service
          * @param initial_queue_size    Number of default fifo queue size (reserve)
          */
-        priority_queue(size_t duration,
+        PriorityQueue(size_t duration,
                        size_t interval,
-                       const std::shared_ptr<tick_service>& tick_service,
+                       const std::shared_ptr<TickService>& tick_service,
                        size_t initial_queue_size)
           : _tick_service(tick_service)
         {
@@ -216,6 +216,6 @@ namespace qtransport {
         size_t _interval_ms;
 
         std::array<std::unique_ptr<timeQueue>, PMAX> _queue;
-        std::shared_ptr<tick_service> _tick_service;
+        std::shared_ptr<TickService> _tick_service;
     };
 }; // end of namespace qtransport

--- a/include/transport/safe_queue.h
+++ b/include/transport/safe_queue.h
@@ -22,7 +22,7 @@ namespace qtransport {
  * @todo Implement any operators or methods needed
  */
 template<typename T>
-class safe_queue
+class SafeQueue
 {
 public:
   /**
@@ -31,13 +31,13 @@ public:
    * @param limit     Limit number of messages in queue before push blocks. Zero
    *                  is unlimited.
    */
-  safe_queue(uint32_t limit = 1000)
+  SafeQueue(uint32_t limit = 1000)
     : _stop_waiting{ false }
     , _limit{ limit }
   {
   }
 
-  ~safe_queue() { stop_waiting(); }
+  ~SafeQueue() { stop_waiting(); }
 
   /**
    * @brief inserts element at the end of queue

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -38,7 +38,7 @@ namespace qtransport {
     /**
      * Interface for services that calculate ticks.
      */
-    struct tick_service
+    struct TickService
     {
         using tick_type = size_t;
         using duration_type = std::chrono::microseconds;
@@ -61,32 +61,32 @@ namespace qtransport {
      *          precision 500us or greater, which results in the tick interval
      *          being >= 500us.
      */
-    class threaded_tick_service : public tick_service
+    class ThreadedTickService : public TickService
     {
         using clock_type = std::chrono::steady_clock;
 
       public:
-        threaded_tick_service() { _tick_thread = std::thread(&threaded_tick_service::tick_loop, this); }
+        ThreadedTickService() { _tick_thread = std::thread(&ThreadedTickService::tick_loop, this); }
 
-        threaded_tick_service(const threaded_tick_service& other)
+        ThreadedTickService(const ThreadedTickService& other)
           : _ticks{ other._ticks }
           , _stop{ other._stop.load() }
         {
-            _tick_thread = std::thread(&threaded_tick_service::tick_loop, this);
+            _tick_thread = std::thread(&ThreadedTickService::tick_loop, this);
         }
 
-        ~threaded_tick_service()
+        ~ThreadedTickService()
         {
             _stop = true;
             if (_tick_thread.joinable())
                 _tick_thread.join();
         }
 
-        threaded_tick_service& operator=(const threaded_tick_service& other)
+        ThreadedTickService& operator=(const ThreadedTickService& other)
         {
             _ticks = other._ticks;
             _stop = other._stop.load();
-            _tick_thread = std::thread(&threaded_tick_service::tick_loop, this);
+            _tick_thread = std::thread(&ThreadedTickService::tick_loop, this);
             return *this;
         }
 
@@ -134,33 +134,33 @@ namespace qtransport {
      *                      the unit for ticks and all associated variables to be millisecond.
      */
     template<typename T, typename Duration_t>
-    class time_queue
+    class TimeQueue
     {
         /*=======================================================================*/
         // Time queue type assertions
         /*=======================================================================*/
 
         template<typename>
-        struct is_chrono_duration : std::false_type
+        struct IsChronoDuration : std::false_type
         {};
 
         template<typename Rep, typename Period>
         struct is_chrono_duration<std::chrono::duration<Rep, Period>> : std::true_type
         {};
 
-        static_assert(is_chrono_duration<Duration_t>::value);
+        static_assert(IsChronoDuration<Duration_t>::value);
 
         /*=======================================================================*/
         // Internal type definitions
         /*=======================================================================*/
 
-        using tick_type = tick_service::tick_type;
+        using tick_type = TickService::tick_type;
         using bucket_type = std::vector<T>;
         using index_type = std::uint32_t;
 
-        struct queue_value_type
+        struct QueueValueType
         {
-            queue_value_type(bucket_type& bucket, index_type value_index, tick_type expiry_tick, tick_type wait_for_tick)
+            QueueValueType(bucket_type& bucket, index_type value_index, tick_type expiry_tick, tick_type wait_for_tick)
               : _bucket{ bucket }
               , _value_index{ value_index }
               , _expiry_tick(expiry_tick)
@@ -174,7 +174,7 @@ namespace qtransport {
             tick_type _wait_for_tick;
         };
 
-        using queue_type = std::vector<queue_value_type>;
+        using queue_type = std::vector<QueueValueType>;
 
       public:
         /**
@@ -187,7 +187,7 @@ namespace qtransport {
          * @throws std::invalid_argument    If the duration or interval do not meet requirements or If the tick_service
          * is null.
          */
-        time_queue(size_t duration, size_t interval, const std::shared_ptr<tick_service>& tick_service)
+        TimeQueue(size_t duration, size_t interval, const std::shared_ptr<TickService>& tick_service)
           : _duration{ duration }
           , _interval{ interval }
           , _total_buckets{ _duration / _interval }
@@ -217,21 +217,21 @@ namespace qtransport {
          * @throws std::invalid_argument If the duration or interval do not meet requirements or the tick_service is
          * null.
          */
-        time_queue(size_t duration,
+        TimeQueue(size_t duration,
                    size_t interval,
-                   const std::shared_ptr<tick_service>& tick_service,
+                   const std::shared_ptr<TickService>& tick_service,
                    size_t initial_queue_size)
-          : time_queue(duration, interval, tick_service)
+          : TimeQueue(duration, interval, tick_service)
         {
             _queue.reserve(initial_queue_size);
         }
 
-        time_queue() = delete;
-        time_queue(const time_queue&) = default;
-        time_queue(time_queue&&) = default;
+        TimeQueue() = delete;
+        TimeQueue(const TimeQueue&) = default;
+        TimeQueue(TimeQueue&&) = default;
 
-        time_queue& operator=(const time_queue&) = default;
-        time_queue& operator=(time_queue&&) = default;
+        TimeQueue& operator=(const TimeQueue&) = default;
+        TimeQueue& operator=(TimeQueue&&) = default;
 
         /**
          * @brief Pushes a new value onto the queue with a time-to-live.
@@ -435,7 +435,7 @@ namespace qtransport {
         queue_type _queue;
 
         /// Tick service for calculating new tick and jumps in time.
-        std::shared_ptr<tick_service> _tick_service;
+        std::shared_ptr<TickService> _tick_service;
     };
 
 }; // namespace qtransport

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -145,7 +145,7 @@ namespace qtransport {
         {};
 
         template<typename Rep, typename Period>
-        struct is_chrono_duration<std::chrono::duration<Rep, Period>> : std::true_type
+        struct IsChronoDuration<std::chrono::duration<Rep, Period>> : std::true_type
         {};
 
         static_assert(IsChronoDuration<Duration_t>::value);

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -273,8 +273,8 @@ public:
    *
    * @return TransportContextId: identifying the connection
    */
-   virtual TransportConnId start(std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples,
-                                 std::shared_ptr<safe_queue<MetricsDataSample>> metrics_data_samples) = 0;
+   virtual TransportConnId start(std::shared_ptr<SafeQueue<MetricsConnSample>> metrics_conn_samples,
+                                 std::shared_ptr<SafeQueue<MetricsDataSample>> metrics_data_samples) = 0;
 
   /**
    * @brief Create a data context
@@ -417,8 +417,8 @@ public:
   virtual std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) = 0;
 
    /// Metrics samples to be written to TSDB. When full the buffer will remove the oldest
-   std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples;
-   std::shared_ptr<safe_queue<MetricsDataSample>> metrics_data_samples;
+   std::shared_ptr<SafeQueue<MetricsConnSample>> metrics_conn_samples;
+   std::shared_ptr<SafeQueue<MetricsDataSample>> metrics_data_samples;
 };
 
 } // namespace qtransport

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -439,8 +439,8 @@ TransportStatus PicoQuicTransport::status() const
 }
 
 TransportConnId
-PicoQuicTransport::start(std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples,
-                         std::shared_ptr<safe_queue<MetricsDataSample>> metrics_data_samples)
+PicoQuicTransport::start(std::shared_ptr<SafeQueue<MetricsConnSample>> metrics_conn_samples,
+                         std::shared_ptr<SafeQueue<MetricsDataSample>> metrics_data_samples)
 {
     this->metrics_conn_samples = std::move(metrics_conn_samples);
     this->metrics_data_samples = std::move(metrics_data_samples);
@@ -690,7 +690,7 @@ PicoQuicTransport::createDataContext(const TransportConnId conn_id,
 
         data_ctx_it->second.priority = priority;
 
-        data_ctx_it->second.tx_data = std::make_unique<priority_queue<ConnData>>(_tconfig.time_queue_max_duration,
+        data_ctx_it->second.tx_data = std::make_unique<PriorityQueue<ConnData>>(_tconfig.time_queue_max_duration,
                                                                                 _tconfig.time_queue_bucket_interval,
                                                                                 _tick_service,
                                                                                 _tconfig.time_queue_init_queue_size);
@@ -853,7 +853,7 @@ PicoQuicTransport::ConnectionContext& PicoQuicTransport::createConnContext(picoq
         logger->info << "Created new connection context for conn_id: " << conn_ctx.conn_id << std::flush;
 
         conn_ctx.dgram_rx_data.set_limit(_tconfig.time_queue_rx_size);
-        conn_ctx.dgram_tx_data = std::make_unique<priority_queue<ConnData>>(_tconfig.time_queue_max_duration,
+        conn_ctx.dgram_tx_data = std::make_unique<PriorityQueue<ConnData>>(_tconfig.time_queue_max_duration,
                                                                             _tconfig.time_queue_bucket_interval,
                                                                             _tick_service,
                                                                             _tconfig.time_queue_init_queue_size);
@@ -890,7 +890,7 @@ PicoQuicTransport::PicoQuicTransport(const TransportRemote& server,
             throw InvalidConfigException("Missing cert key filename");
         }
     }
-    _tick_service = std::make_shared<threaded_tick_service>();
+    _tick_service = std::make_shared<ThreadedTickService>();
 }
 
 PicoQuicTransport::~PicoQuicTransport()
@@ -926,7 +926,7 @@ PicoQuicTransport::DataContext* PicoQuicTransport::createDataContextBiDirRecv(Tr
 
         data_ctx_it->second.priority = 10; // TODO: Need to get priority from remote
 
-        data_ctx_it->second.tx_data = std::make_unique<priority_queue<ConnData>>(_tconfig.time_queue_max_duration,
+        data_ctx_it->second.tx_data = std::make_unique<PriorityQueue<ConnData>>(_tconfig.time_queue_max_duration,
                                                                                 _tconfig.time_queue_bucket_interval,
                                                                                 _tick_service,
                                                                                 _tconfig.time_queue_init_queue_size);

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -40,7 +40,7 @@ class PicoQuicTransport : public ITransport
     const char* QUICR_ALPN = "moq-00";
 
     using bytes_t = std::vector<uint8_t>;
-    using timeQueue = time_queue<bytes_t, std::chrono::milliseconds>;
+    using timeQueue = TimeQueue<bytes_t, std::chrono::milliseconds>;
     using DataContextId = uint64_t;
 
     /**
@@ -70,7 +70,7 @@ class PicoQuicTransport : public ITransport
 
         uint64_t in_data_cb_skip_count {0};                  /// Number of times callback was skipped due to size
 
-        std::unique_ptr<priority_queue<ConnData>> tx_data;    /// Pending objects to be written to the network
+        std::unique_ptr<PriorityQueue<ConnData>> tx_data;    /// Pending objects to be written to the network
 
         uint8_t* stream_tx_object {nullptr};                 /// Current object that is being sent as a byte stream
         size_t stream_tx_object_size {0};                    /// Size of the tx object
@@ -122,8 +122,8 @@ class PicoQuicTransport : public ITransport
         DataContextId next_data_ctx_id {1};                   /// Next data context ID; zero is reserved for default context
 
 
-        std::unique_ptr<priority_queue<ConnData>> dgram_tx_data;  /// Datagram pending objects to be written to the network
-        safe_queue<bytes_t> dgram_rx_data;                        /// Buffered datagrams received from the network
+        std::unique_ptr<PriorityQueue<ConnData>> dgram_tx_data;  /// Datagram pending objects to be written to the network
+        SafeQueue<bytes_t> dgram_rx_data;                        /// Buffered datagrams received from the network
 
         /**
          * Active stream buffers for received unidirectional streams
@@ -206,8 +206,8 @@ class PicoQuicTransport : public ITransport
     virtual ~PicoQuicTransport();
 
     TransportStatus status() const override;
-    TransportConnId start(std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples,
-                          std::shared_ptr<safe_queue<MetricsDataSample>> metrics_data_samples) override;
+    TransportConnId start(std::shared_ptr<SafeQueue<MetricsConnSample>> metrics_conn_samples,
+                          std::shared_ptr<SafeQueue<MetricsDataSample>> metrics_data_samples) override;
     void close(const TransportConnId& conn_id, uint64_t app_reason_code=0) override;
 
     virtual bool getPeerAddrInfo(const TransportConnId& conn_id,
@@ -346,9 +346,9 @@ class PicoQuicTransport : public ITransport
     picoquic_quic_config_t _config;
     picoquic_quic_t* _quic_ctx;
     picoquic_tp_t _local_tp_options;
-    safe_queue<std::function<void()>> _cbNotifyQueue;
+    SafeQueue<std::function<void()>> _cbNotifyQueue;
 
-    safe_queue<std::function<void()>> _picoquic_runner_queue;        /// Threads queue functions that picoquic will call via the pq_loop_cb call
+    SafeQueue<std::function<void()>> _picoquic_runner_queue;        /// Threads queue functions that picoquic will call via the pq_loop_cb call
 
     std::atomic<bool> _stop;
     std::mutex _state_mutex;                                        /// Used for stream/context/state updates
@@ -361,7 +361,7 @@ class PicoQuicTransport : public ITransport
     TransportConfig _tconfig;
 
     std::map<TransportConnId, ConnectionContext> _conn_context;
-    std::shared_ptr<tick_service> _tick_service;
+    std::shared_ptr<TickService> _tick_service;
 };
 
 } // namespace qtransport

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -73,7 +73,7 @@ UDPTransport::UDPTransport(const TransportRemote &server,
     _fd(-1),
     _isServerMode(isServerMode),
     _serverInfo(server), _delegate(delegate) {
-    _tick_service = std::make_shared<threaded_tick_service>();
+    _tick_service = std::make_shared<ThreadedTickService>();
 }
 
 TransportStatus UDPTransport::status() const {
@@ -118,8 +118,8 @@ DataContextId UDPTransport::createDataContext(const qtransport::TransportConnId 
     return data_ctx_id;
 }
 
-TransportConnId UDPTransport::start(std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples,
-                                    std::shared_ptr<safe_queue<MetricsDataSample>> metrics_data_samples) {
+TransportConnId UDPTransport::start(std::shared_ptr<SafeQueue<MetricsConnSample>> metrics_conn_samples,
+                                    std::shared_ptr<SafeQueue<MetricsDataSample>> metrics_data_samples) {
 
     this->metrics_conn_samples = std::move(metrics_conn_samples);
     this->metrics_data_samples = std::move(metrics_data_samples);
@@ -712,7 +712,7 @@ UDPTransport::fd_reader() {
                                                                         std::make_shared<ConnectionContext>());
 
                         auto &conn = *conn_it->second;
-                        conn.tx_data = std::make_unique<priority_queue<ConnData>>(_tconfig.time_queue_max_duration,
+                        conn.tx_data = std::make_unique<PriorityQueue<ConnData>>(_tconfig.time_queue_max_duration,
                                                                                   _tconfig.time_queue_bucket_interval,
                                                                                   _tick_service,
                                                                                   _tconfig.time_queue_init_queue_size);
@@ -1201,7 +1201,7 @@ int err = 0;
     auto &conn = *conn_it->second;
     conn.addr = _serverAddr;
     conn.id = _last_conn_id;
-    conn.tx_data = std::make_unique<priority_queue<ConnData>>(_tconfig.time_queue_max_duration,
+    conn.tx_data = std::make_unique<PriorityQueue<ConnData>>(_tconfig.time_queue_max_duration,
                                                               _tconfig.time_queue_bucket_interval,
                                                               _tick_service,
                                                               _tconfig.time_queue_init_queue_size);

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -58,8 +58,8 @@ namespace qtransport {
 
         TransportStatus status() const override;
 
-      TransportConnId start(std::shared_ptr<safe_queue<MetricsConnSample>> metrics_conn_samples,
-                            std::shared_ptr<safe_queue<MetricsDataSample>> metrics_data_samples) override;
+      TransportConnId start(std::shared_ptr<SafeQueue<MetricsConnSample>> metrics_conn_samples,
+                            std::shared_ptr<SafeQueue<MetricsDataSample>> metrics_data_samples) override;
 
         void close(const TransportConnId &conn_id, uint64_t app_reason_code=0) override;
 
@@ -136,7 +136,7 @@ namespace qtransport {
 
             uint64_t in_data_cb_skip_count {0};               /// Number of times callback was skipped due to size
 
-            safe_queue<ConnData> rx_data;                     /// Receive queue
+            SafeQueue<ConnData> rx_data;                     /// Receive queue
         };
 
         struct ConnectionContext {
@@ -148,7 +148,7 @@ namespace qtransport {
             UdpConnectionMetrics metrics;
 
             TransportStatus status { TransportStatus::Disconnected };
-            std::unique_ptr<priority_queue<ConnData>> tx_data;  // TX priority queue
+            std::unique_ptr<PriorityQueue<ConnData>> tx_data;  // TX priority queue
 
             uint64_t last_rx_msg_tick { 0 };            /// Tick value (ms) when last message was received
             uint64_t last_tx_msg_tick { 0 };            /// Tick value (ms) when last message was sent
@@ -283,7 +283,7 @@ namespace qtransport {
         std::map<TransportConnId, std::shared_ptr<ConnectionContext>> _conn_contexts;
         std::map<AddrId, std::shared_ptr<ConnectionContext>> _addr_conn_contexts;
 
-        std::shared_ptr<tick_service> _tick_service;
+        std::shared_ptr<TickService> _tick_service;
     };
 
 } // namespace qtransport


### PR DESCRIPTION
Rule & auto fix for existing CamelCase rule. 

Almost everything already adhered to this, except for the `*_queue` and `tick_service` types. 