### PR TITLE
Add const related clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,12 @@
-Checks: '-*,readability-identifier-naming'
+Checks: '
+          -*,
+          misc-misplaced-const,
+          readability-avoid-const-params-in-decls,
+          readability-const-return-type,
+          readability-identifier-naming,
+          readability-make-member-function-const,
+          readability-non-const-parameter,
+        '
 CheckOptions:
   - { key: readability-identifier-naming.PrivateMemberPrefix, value: _ }
 WarningsAsErrors: "*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,8 @@ if (LINT)
   find_program(CLANG_TIDY_EXE clang-tidy REQUIRED)
   set_target_properties(quicr-transport
     PROPERTIES
-      CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+      CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+      CXX_CLANG_TIDY_EXPORT_FIXES_DIR "clang-tidy-fixes")
 endif (LINT)
 
 target_compile_options(quicr-transport

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -162,7 +162,7 @@ public:
      * @param[in] status 	    Transport Status value
      */
     virtual void on_connection_status(const TransportConnId& conn_id,
-                                      const TransportStatus status) = 0;
+                                      TransportStatus status) = 0;
 
     /**
      * @brief Report arrival of a new connection
@@ -209,7 +209,7 @@ public:
     virtual void on_recv_stream(const TransportConnId& conn_id,
                                 uint64_t stream_id,
                                 std::optional<DataContextId> data_ctx_id,
-                                const bool is_bidir=false) = 0;
+                                bool is_bidir=false) = 0;
 
 
   };
@@ -289,7 +289,7 @@ public:
    *
    * @return DataContextId identifying the data context via the connection
    */
-  virtual DataContextId createDataContext(const TransportConnId conn_id,
+  virtual DataContextId createDataContext(TransportConnId conn_id,
                                           bool use_reliable_transport,
                                           uint8_t priority = 1,
                                           bool bidir = false) = 0;
@@ -330,7 +330,7 @@ public:
    * @param data_ctx_id             Local data context ID
    * @param stream_id               RX stream ID
    */
-   virtual void setStreamIdDataCtxId(const TransportConnId conn_id,
+   virtual void setStreamIdDataCtxId(TransportConnId conn_id,
                                     DataContextId data_ctx_id,
                                     uint64_t stream_id) = 0;
 
@@ -341,7 +341,7 @@ public:
    * @param data_ctx_id             Local data context ID
    * @param priority                Priority for data context stream, range should be 0 - 255
    */
-  virtual void setDataCtxPriority(const TransportConnId conn_id, DataContextId data_ctx_id, uint8_t priority) = 0;
+  virtual void setDataCtxPriority(TransportConnId conn_id, DataContextId data_ctx_id, uint8_t priority) = 0;
 
   /**
    * @brief Set the remote data context id
@@ -351,9 +351,9 @@ public:
    * @param data_ctx_id              Local data context ID
    * @param remote_data_ctx_id       Remote data context ID (learned via subscribe/publish)
    */
-  virtual void setRemoteDataCtxId(const TransportConnId conn_id,
-                                  const DataContextId data_ctx_id,
-                                  const DataContextId remote_data_ctx_id) = 0;
+  virtual void setRemoteDataCtxId(TransportConnId conn_id,
+                                  DataContextId data_ctx_id,
+                                  DataContextId remote_data_ctx_id) = 0;
 
 
   /**
@@ -388,10 +388,10 @@ public:
                                  const DataContextId& data_ctx_id,
                                  std::vector<uint8_t>&& bytes,
                                  std::vector<MethodTraceItem> &&trace = { MethodTraceItem{} },
-                                 const uint8_t priority = 1,
-                                 const uint32_t ttl_ms=350,
-                                 const uint32_t delay_ms=0,
-                                 const EnqueueFlags flags={true, false, false, false}) = 0;
+                                 uint8_t priority = 1,
+                                 uint32_t ttl_ms=350,
+                                 uint32_t delay_ms=0,
+                                 EnqueueFlags flags={true, false, false, false}) = 0;
 
   /**
    * @brief Dequeue datagram application data from transport buffer

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -213,7 +213,7 @@ class PicoQuicTransport : public ITransport
     virtual bool getPeerAddrInfo(const TransportConnId& conn_id,
                                  sockaddr_storage* addr) override;
 
-    DataContextId createDataContext(const TransportConnId conn_id,
+    DataContextId createDataContext(TransportConnId conn_id,
                                     bool use_reliable_transport,
                                     uint8_t priority, bool bidir) override;
 
@@ -224,22 +224,22 @@ class PicoQuicTransport : public ITransport
                            const DataContextId& data_ctx_id,
                            std::vector<uint8_t>&& bytes,
                            std::vector<qtransport::MethodTraceItem> &&trace,
-                           const uint8_t priority,
-                           const uint32_t ttl_ms,
-                           const uint32_t delay_ms,
-                           const EnqueueFlags flags) override;
+                           uint8_t priority,
+                           uint32_t ttl_ms,
+                           uint32_t delay_ms,
+                           EnqueueFlags flags) override;
 
     std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
                                                 std::optional<DataContextId> data_ctx_id) override;
 
     std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) override;
 
-    void setRemoteDataCtxId(const TransportConnId conn_id,
-                            const DataContextId data_ctx_id,
-                            const DataContextId remote_data_ctx_id) override;
+    void setRemoteDataCtxId(TransportConnId conn_id,
+                            DataContextId data_ctx_id,
+                            DataContextId remote_data_ctx_id) override;
 
-    void setStreamIdDataCtxId(const TransportConnId conn_id, DataContextId data_ctx_id, uint64_t stream_id) override;
-    void setDataCtxPriority(const TransportConnId conn_id, DataContextId data_ctx_id, uint8_t priority) override;
+    void setStreamIdDataCtxId(TransportConnId conn_id, DataContextId data_ctx_id, uint64_t stream_id) override;
+    void setDataCtxPriority(TransportConnId conn_id, DataContextId data_ctx_id, uint8_t priority) override;
 
     /*
      * Internal public methods
@@ -265,10 +265,10 @@ class PicoQuicTransport : public ITransport
     void send_next_datagram(ConnectionContext* conn_ctx, uint8_t* bytes_ctx, size_t max_len);
     void send_stream_bytes(DataContext* data_ctx, uint8_t* bytes_ctx, size_t max_len);
 
-    void on_connection_status(const TransportConnId conn_id,
-                              const TransportStatus status);
+    void on_connection_status(TransportConnId conn_id,
+                              TransportStatus status);
 
-    void on_new_connection(const TransportConnId conn_id);
+    void on_new_connection(TransportConnId conn_id);
     void on_recv_datagram(ConnectionContext* conn_ctx,
                           uint8_t* bytes, size_t length);
     void on_recv_stream_bytes(ConnectionContext *conn_ctx, DataContext* data_ctx, uint64_t stream_id,
@@ -301,7 +301,7 @@ class PicoQuicTransport : public ITransport
     void shutdown();
 
     void server();
-    void client(const TransportConnId conn_id);
+    void client(TransportConnId conn_id);
     void cbNotifier();
 
     void check_callback_delta(DataContext* data_ctx, bool tx=true);
@@ -311,14 +311,14 @@ class PicoQuicTransport : public ITransport
      * @details This method MUST only be called within the picoquic thread. Enqueue and other
      *      thread methods can call this via the pq_runner.
      */
-    void mark_stream_active(const TransportConnId conn_id, const DataContextId data_ctx_id);
+    void mark_stream_active(TransportConnId conn_id, DataContextId data_ctx_id);
 
     /**
      * @brief Mark datagram ready
      * @details This method MUST only be called within the picoquic thread. Enqueue and other
      *      thread methods can call this via the pq_runner.
      */
-    void mark_dgram_ready(const TransportConnId conn_id);
+    void mark_dgram_ready(TransportConnId conn_id);
 
     /**
      * @brief Create a new stream
@@ -337,7 +337,7 @@ class PicoQuicTransport : public ITransport
      * @param data_ctx      Data context for the stream
      * @param send_reset    Indicates if the stream should be closed by RESET, otherwise FIN
      */
-    void close_stream(ConnectionContext& conn_ctx, DataContext *data_ctx, const bool send_reset);
+    void close_stream(ConnectionContext& conn_ctx, DataContext *data_ctx, bool send_reset);
 
 
     /*

--- a/src/transport_udp.h
+++ b/src/transport_udp.h
@@ -66,7 +66,7 @@ namespace qtransport {
         virtual bool getPeerAddrInfo(const TransportConnId &conn_id,
                                      sockaddr_storage *addr) override;
 
-        DataContextId createDataContext(const TransportConnId conn_id,
+        DataContextId createDataContext(TransportConnId conn_id,
                                         bool use_reliable_transport,
                                         uint8_t priority, bool bidir) override;
 
@@ -76,19 +76,19 @@ namespace qtransport {
                                const DataContextId &data_ctx_id,
                                std::vector<uint8_t> &&bytes,
                                std::vector<qtransport::MethodTraceItem> &&trace,
-                               const uint8_t priority,
-                               const uint32_t ttl_ms,
-                               const uint32_t delay_ms,
-                               const EnqueueFlags flags) override;
+                               uint8_t priority,
+                               uint32_t ttl_ms,
+                               uint32_t delay_ms,
+                               EnqueueFlags flags) override;
 
         std::optional<std::vector<uint8_t>> dequeue(TransportConnId conn_id,
                                                     std::optional<DataContextId> data_ctx_id) override;
 
         std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId conn_id, uint64_t stream_id) override { return nullptr;}
 
-        void setRemoteDataCtxId(const TransportConnId conn_id,
-                                const DataContextId data_ctx_id,
-                                const DataContextId remote_data_ctx_id) override;
+        void setRemoteDataCtxId(TransportConnId conn_id,
+                                DataContextId data_ctx_id,
+                                DataContextId remote_data_ctx_id) override;
 
         void setStreamIdDataCtxId([[maybe_unused]] const TransportConnId conn_id,
                                   [[maybe_unused]] DataContextId data_ctx_id,
@@ -209,7 +209,7 @@ namespace qtransport {
          *
          * @return True if sent, false if not sent/error
          */
-        bool send_connect(const TransportConnId conn_id, const Addr& addr);
+        bool send_connect(TransportConnId conn_id, const Addr& addr);
 
         /**
          * @brief Send UDP protocol connect OK message
@@ -219,7 +219,7 @@ namespace qtransport {
          *
          * @return True if sent, false if not sent/error
          */
-        bool send_connect_ok(const TransportConnId conn_id, const Addr& addr);
+        bool send_connect_ok(TransportConnId conn_id, const Addr& addr);
 
         /**
          * @brief Send UDP protocol disconnect message
@@ -229,7 +229,7 @@ namespace qtransport {
          *
          * @return True if sent, false if not sent/error
          */
-        bool send_disconnect(const TransportConnId conn_id, const Addr& addr);
+        bool send_disconnect(TransportConnId conn_id, const Addr& addr);
 
         /**
          * @brief Send UDP protocol keepalive message


### PR DESCRIPTION
Only changes here are to remove const usages per [readability-avoid-const-params-in-decls](https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-const-params-in-decls.html)