### PR TITLE
Add & fix clang tidy performance rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,8 @@
 Checks: '
           -*,
+          clang-analyzer-*,
           misc-misplaced-const,
+          performance-*,
           readability-avoid-const-params-in-decls,
           readability-const-return-type,
           readability-identifier-naming,

--- a/include/transport/span.h
+++ b/include/transport/span.h
@@ -20,10 +20,10 @@ class Span
     static constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
 
     template<typename Ptr>
-    class iterator_impl : public std::iterator_traits<Ptr>
+    class IteratorImpl : public std::iterator_traits<Ptr>
     {
         using it_traits = std::iterator_traits<Ptr>;
-        using it_impl   = iterator_impl;
+        using it_impl   = IteratorImpl;
 
     public:
         using value_type        = typename it_traits::value_type;
@@ -32,14 +32,14 @@ class Span
         using difference_type   = typename it_traits::difference_type;
         using iterator_category = typename it_traits::iterator_category;
 
-        constexpr iterator_impl() noexcept : _ptr(Ptr()) {}
-        constexpr iterator_impl(const pointer& ptr) noexcept : _ptr(ptr) {}
-        constexpr iterator_impl(const iterator_impl&) = default;
+        constexpr IteratorImpl() noexcept : _ptr(Ptr()) {}
+        constexpr IteratorImpl(const pointer& ptr) noexcept : _ptr(ptr) {}
+        constexpr IteratorImpl(const IteratorImpl&) = default;
 
         template<typename OtherIt>
-        iterator_impl(const iterator_impl<OtherIt>& other) : _ptr(other.base()) {}
+        IteratorImpl(const IteratorImpl<OtherIt>& other) : _ptr(other.base()) {}
 
-        iterator_impl& operator=(const iterator_impl&) = default;
+        IteratorImpl& operator=(const IteratorImpl&) = default;
 
         constexpr reference operator*() const noexcept { return *_ptr; }
         constexpr pointer operator->() const noexcept { return _ptr; }
@@ -96,8 +96,8 @@ public:
     using const_pointer             = const T*;
     using reference                 = T&;
     using const_reference           = const T&;
-    using iterator                  = iterator_impl<pointer>;
-    using const_iterator            = iterator_impl<const_pointer>;
+    using iterator                  = IteratorImpl<pointer>;
+    using const_iterator            = IteratorImpl<const_pointer>;
     using reverse_iterator          = std::reverse_iterator<iterator>;
     using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
 

--- a/include/transport/time_queue.h
+++ b/include/transport/time_queue.h
@@ -228,10 +228,10 @@ namespace qtransport {
 
         TimeQueue() = delete;
         TimeQueue(const TimeQueue&) = default;
-        TimeQueue(TimeQueue&&) = default;
+        TimeQueue(TimeQueue&&) noexcept = default;
 
         TimeQueue& operator=(const TimeQueue&) = default;
-        TimeQueue& operator=(TimeQueue&&) = default;
+        TimeQueue& operator=(TimeQueue&&) noexcept = default;
 
         /**
          * @brief Pushes a new value onto the queue with a time-to-live.

--- a/include/transport/transport.h
+++ b/include/transport/transport.h
@@ -52,7 +52,7 @@ enum class TransportError : uint8_t
 /**
  * Transport Protocol to use
  */
-enum class TransportProtocol
+enum class TransportProtocol: uint8_t
 {
   UDP = 0,
   QUIC
@@ -108,7 +108,7 @@ struct MethodTraceItem {
         delta(0) {
     }
 
-    MethodTraceItem(const std::string method, const time_stamp_us start_time) :
+    MethodTraceItem(const std::string& method, const time_stamp_us start_time) :
             method(method),
             start_time(start_time) {
         delta = (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::steady_clock::now()) -

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -326,7 +326,7 @@ int pq_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void
     int ret = 0;
 
     if (transport == NULL) {
-        std::cerr << "picoquic transport was called with NULL transport" << std::endl;
+        std::cerr << "picoquic transport was called with NULL transport" << '\n';
         return PICOQUIC_ERROR_UNEXPECTED_ERROR;
 
     } else if (transport->status() == TransportStatus::Disconnected) {
@@ -1336,7 +1336,7 @@ PicoQuicTransport::on_recv_datagram(ConnectionContext* conn_ctx, uint8_t* bytes,
 
     std::vector<uint8_t> data(bytes, bytes + length);
 
-    conn_ctx->dgram_rx_data.push(std::move(data));
+    conn_ctx->dgram_rx_data.push(data);
     conn_ctx->metrics.rx_dgrams++;
     conn_ctx->metrics.rx_dgrams_bytes += length;
 
@@ -1680,7 +1680,7 @@ TransportConnId PicoQuicTransport::createClient()
         logger->info << "Setting priority bypass limit to " << static_cast<int>(_tconfig.quic_priority_limit) << std::flush;
         picoquic_set_priority_limit_for_bypass(cnx, _tconfig.quic_priority_limit);
     } else {
-        logger->info << "No priority bypass" << std::endl;
+        logger->info << "No priority bypass" << '\n';
     }
 
 //    picoquic_subscribe_pacing_rate_updates(cnx, tconfig.pacing_decrease_threshold_Bps,

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -227,7 +227,7 @@ AddrId UDPTransport::create_addr_id(const sockaddr_storage &addr) {
         }
     }
 
-    return std::move(id);
+    return id;
 }
 
 TransportRemote UDPTransport::create_addr_remote(const sockaddr_storage &addr) {
@@ -741,7 +741,7 @@ UDPTransport::fd_reader() {
                                       << " port: " << remote.port << std::flush;
 
                         // Notify caller that there is a new connection
-                        _delegate.on_new_connection(_last_conn_id, std::move(remote));
+                        _delegate.on_new_connection(_last_conn_id, remote);
                         continue;
 
                     } else {


### PR DESCRIPTION
~(Includes #163 for CI fix)~

Adds `clang-analyzer-*` checks (no changes needed) and the `performance-checks-*` which did have some (minor, but useful if just for consistency) fixes. I will comment them individually. 