### PR TITLE
Update stream_buffer.h

### DIFF
--- a/include/transport/stream_buffer.h
+++ b/include/transport/stream_buffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <any>
 #include <deque>
 #include <mutex>


### PR DESCRIPTION
Adds `<algorithm>` header. This missing seems to be causing some issues specifically about finding `std::copy_n` over `std::copy` in libquicr tests on linux/gcc. Ref: https://github.com/Quicr/libquicr/actions/runs/10401351227/job/28803716878