### PR TITLE
Include what you use

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: '
           -*,
           clang-analyzer-*,
+          misc-include-cleaner,
           misc-misplaced-const,
           performance-*,
           readability-avoid-const-params-in-decls,

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -3,6 +3,10 @@
 #if not defined(PLATFORM_ESP)
   #include <transport_picoquic.h>
 #endif
+#include <memory>
+#include <stdexcept>
+#include <spdlog/logger.h>
+#include <utility>
 
 namespace qtransport {
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1,27 +1,48 @@
 #include "transport_picoquic.h"
 
+// PicoQuic.
+#include <picoquic.h>
 #include <picoquic_internal.h>
+#include <picoquic_packet_loop.h>
 #include <autoqlog.h>
 #include <picoquic_utils.h>
 #include <spdlog/spdlog.h>
+#include <picoquic_config.h>
+#include <picosocks.h>
 
+// Transport.
+#include "transport/transport.h"
+#include "transport/transport_metrics.h"
+#include "transport/safe_queue.h"
+#include "transport/stream_buffer.h"
+#include "transport/priority_queue.h"
+#include "transport/span.h"
+#include "transport/time_queue.h"
+#include <spdlog/logger.h>
+
+// System.
 #include <arpa/inet.h>
+#include <sys/socket.h>
 #include <cassert>
 #include <cstring>
 #include <ctime>
 #include <iostream>
 #include <thread>
-#include <unistd.h>
 #include <sstream>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <memory>
+#include <mutex>
+#include <vector>
+#include <string>
+#include <chrono>
+#include <sstream>
+#include <stdexcept>
 
-#include <arpa/inet.h>
-#include <sys/select.h>
-#include <netdb.h>
 #if defined(__linux__)
 #include <net/ethernet.h>
 #include <netpacket/packet.h>
-#elif defined(__APPLE__)
-#include <net/if_dl.h>
 #endif
 
 #define LOGGER_TRACE(logger, ...) if (logger) SPDLOG_LOGGER_TRACE(logger, __VA_ARGS__)
@@ -821,7 +842,7 @@ PicoQuicTransport::ConnectionContext& PicoQuicTransport::createConnContext(picoq
                             /*(const void*)(&((struct sockaddr_in*)addr)->sin_addr),*/
                             conn_ctx.peer_addr_text,
                             sizeof(conn_ctx.peer_addr_text));
-            conn_ctx.peer_port = ntohs(((struct sockaddr_in*)addr)->sin_port);
+            conn_ctx.peer_port = ntohs(((struct sockaddr_in*)addr)->sin_port); // NOLINT (include)
             break;
 
         case AF_INET6:

--- a/src/transport_udp.cpp
+++ b/src/transport_udp.cpp
@@ -1,24 +1,43 @@
 #include <cassert>
 #include <cstring> // memcpy
 #include <iostream>
-#include <thread>
 #include <sstream>
 #include <unistd.h>
+#include <optional>
+#include <memory>
+#include <cstdint>
+#include <mutex>
+#include <utility>
+#include <vector>
+#include <chrono>
+#include <string>
+#include <sstream>
+#include <stdexcept>
 
+#include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/select.h> // IWYU pragma: keep
+#include <sys/time.h> // IWYU pragma: keep
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <errno.h>
 
 #if defined(__linux__)
 #include <net/ethernet.h>
 #include <netpacket/packet.h>
-#elif defined(__APPLE__)
-
-#include <net/if_dl.h>
-
 #endif
 
 #include "transport_udp.h"
+#include "transport_udp_protocol.h"
+
+#include "transport/transport.h"
+#include "transport/time_queue.h"
+#include "transport/transport_metrics.h"
+#include "transport/uintvar.h"
+#include "transport/priority_queue.h"
+#include <spdlog/spdlog.h>
+#include <spdlog/logger.h>
+
 
 #if defined(PLATFORM_ESP)
 #include <lwip/netdb.h>
@@ -485,7 +504,7 @@ bool UDPTransport::send_data(ConnectionContext& conn, DataContext& data_ctx, con
  *  - loop reads data from fd_write_queue and writes it to the socket
  */
 void UDPTransport::fd_writer() {
-    timeval to;
+    timeval to; // NOLINT (include).
     to.tv_usec = 1000;
     to.tv_sec = 0;
 
@@ -595,7 +614,7 @@ void UDPTransport::fd_writer() {
             if (all_empty_count > 5) {
                 all_empty_count = 1;
                 to.tv_usec = 300;
-                select(0, NULL, NULL, NULL, &to);
+                select(0, NULL, NULL, NULL, &to); // NOLINT (include).
             }
         }
 
@@ -1124,7 +1143,7 @@ int err = 0;
 
     struct sockaddr_in srvAddr;
     srvAddr.sin_family = AF_INET;
-    srvAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    srvAddr.sin_addr.s_addr = htonl(INADDR_ANY); // NOLINT (include).
     srvAddr.sin_port = 0;
     err = bind(_fd, (struct sockaddr *) &srvAddr, sizeof(srvAddr));
     if (err) {
@@ -1137,7 +1156,7 @@ int err = 0;
 #endif
     }
 
-    std::string sPort = std::to_string(htons(_serverInfo.port));
+    std::string sPort = std::to_string(htons(_serverInfo.port)); // NOLINT (include).
     struct addrinfo hints = {}, *address_list = NULL;
     hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_DGRAM;


### PR DESCRIPTION
There are a couple of things to call out here:

1. I have done this naively. We may want consumers of this API (and ourselves) to only have to include `<transport/transport.h>` to get all/some subset of the `<transport/*.h>` headers. We can add a pragma to mark those as exported that will be understood if they/us run clang-tidy or IWYU. Perhaps the existing ones transport includes already would make sense(?): cc @TimEvens 

```cpp
#include <transport/uintvar.h>
#include <transport/safe_queue.h>
#include <transport/transport_metrics.h>
#include <transport/stream_buffer.h>
```

2. On MacOS at least, IncludeCleaner suggests some private MacOS headers that contain the actual implementations rather than the more canonical UNIX headers. E.g `timeval` should come from `sys/time.h` not `sys/types/_timeval.h`. IWYU allows a mapping file to correct these, but clang-tidy's version doesn't seem to. I have marked them NOLINT for now.