### PR TITLE
Add CMake module for lint function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,8 @@ set_target_properties(quicr-transport
 
 # linting
 if (LINT)
-  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-  find_program(CLANG_TIDY_EXE clang-tidy REQUIRED)
-  set_target_properties(quicr-transport
-    PROPERTIES
-      CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
-      CXX_CLANG_TIDY_EXPORT_FIXES_DIR "clang-tidy-fixes")
+  include(Lint)
+  lint(quicr-transport)
 endif (LINT)
 
 target_compile_options(quicr-transport

--- a/cmake/Lint.cmake
+++ b/cmake/Lint.cmake
@@ -1,0 +1,8 @@
+function(lint target)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    find_program(CLANG_TIDY_EXE clang-tidy REQUIRED)
+    set_target_properties(${target}
+        PROPERTIES
+            CXX_CLANG_TIDY "${CLANG_TIDY_EXE}"
+            CXX_CLANG_TIDY_EXPORT_FIXES_DIR "clang-tidy-fixes")
+endfunction()


### PR DESCRIPTION
Extract target linting logic to CMake module so it can be easily consumed (and by other quicr projects). 